### PR TITLE
Fixed broken links in menu-button.mdx

### DIFF
--- a/www/src/pages/menu-button.mdx
+++ b/www/src/pages/menu-button.mdx
@@ -104,7 +104,7 @@ Wraps a DOM `button` that toggles the opening and closing of the dropdown menu. 
 
 ## MenuButton CSS Selectors
 
-Please see the [styling guide](/styles).
+Please see the [styling guide](/styling).
 
 No styles are applied to the underlying `button`, so style it like any other button in your app.
 
@@ -250,7 +250,7 @@ Handles menu selection. Must be a direct child of a `<MenuList>`.
 
 ## MenuItem CSS Selectors
 
-Please see the [styling guide](/styles).
+Please see the [styling guide](/styling).
 
 ```css
 [data-reach-menu-item] {
@@ -387,7 +387,7 @@ Must be a direct child of a `<MenuList>`.
 
 ## MenuLink CSS Selectors
 
-Please see the [styling guide](/styles).
+Please see the [styling guide](/styling).
 
 ```css
 [data-reach-menu-item] {


### PR DESCRIPTION
Links to styling were broken. Now, they are not