### PR TITLE
Fix memory leak with event handler in WindowSize component.

### DIFF
--- a/packages/window-size/src/index.js
+++ b/packages/window-size/src/index.js
@@ -11,7 +11,7 @@ let didMount = ({ refs, setState }) => {
     });
   window.addEventListener("resize", resize);
   refs.removeEvent = () => {
-    window.addEventListener("resize", resize);
+    window.removeEventListener("resize", resize);
   };
 };
 


### PR DESCRIPTION
Simple fix for unintentionally calling `addEventListener` inside `removeEvent`.