### PR TITLE
Handle menu collision at bottom, and at bottom and right

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -393,31 +393,25 @@ let getStyles = (buttonRect, menuRect) => {
     styles.minWidth = buttonRect.width;
   }
 
-  let collisionRight = window.innerWidth < buttonRect.left + menuRect.width;
-  let collisionBottom = window.innerHeight < buttonRect.top + menuRect.height;
-  let collisionRightAndBottom = collisionRight && collisionBottom;
+  let collisions = {
+    top: buttonRect.top - menuRect.height < 0,
+    right: window.innerWidth < buttonRect.left + menuRect.width,
+    bottom: window.innerHeight < buttonRect.top + menuRect.height,
+    left: buttonRect.left - menuRect.width < 0
+  };
 
-  if (collisionRightAndBottom) {
-    return {
-      ...styles,
-      left: `${buttonRect.right - menuRect.width + window.scrollX}px`,
-      top: `${buttonRect.top - menuRect.height + window.scrollY}px`
-    };
-  } else if (collisionRight) {
-    return {
-      ...styles,
-      left: `${buttonRect.right - menuRect.width + window.scrollX}px`,
-      top: `${buttonRect.top + buttonRect.height + window.scrollY}px`
-    };
-  } else if (collisionBottom) {
-    return {
-      ...styles,
-      left: `${buttonRect.left + window.scrollX}px`,
-      top: `${buttonRect.top - menuRect.height + window.scrollY}px`
-    };
-  } else {
-    return styles;
-  }
+  const directionRight = collisions.right && !collisions.left;
+  const directionUp = collisions.bottom && !collisions.top;
+
+  return {
+    ...styles,
+    left: directionRight
+      ? `${buttonRect.right - menuRect.width + window.scrollX}px`
+      : `${buttonRect.left + window.scrollX}px`,
+    top: directionUp
+      ? `${buttonRect.top - menuRect.height + window.scrollY}px`
+      : `${buttonRect.top + buttonRect.height + window.scrollY}px`
+  };
 };
 
 export { Menu, MenuList, MenuButton, MenuLink, MenuItem };

--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -369,9 +369,6 @@ MenuLink.propTypes = {
   _ref: func
 };
 
-// TODO: Deal with collisions on the bottom, though not as important
-// since focus causes a scroll and will then scroll the page down
-// to the item.
 let getStyles = (buttonRect, menuRect) => {
   let haventMeasuredButtonYet = !buttonRect;
   if (haventMeasuredButtonYet) {
@@ -397,15 +394,27 @@ let getStyles = (buttonRect, menuRect) => {
   }
 
   let collisionRight = window.innerWidth < buttonRect.left + menuRect.width;
-  // let collisionBottom = window.innerHeight < buttonRect.top + menuRect.height;
+  let collisionBottom = window.innerHeight < buttonRect.top + menuRect.height;
+  let collisionRightAndBottom = collisionRight && collisionBottom;
 
-  if (collisionRight) {
+  if (collisionRightAndBottom) {
+    return {
+      ...styles,
+      left: `${buttonRect.right - menuRect.width + window.scrollX}px`,
+      top: `${buttonRect.top - menuRect.height + window.scrollY}px`
+    };
+  } else if (collisionRight) {
     return {
       ...styles,
       left: `${buttonRect.right - menuRect.width + window.scrollX}px`,
       top: `${buttonRect.top + buttonRect.height + window.scrollY}px`
     };
-    // } else if (collisionBottom) {
+  } else if (collisionBottom) {
+    return {
+      ...styles,
+      left: `${buttonRect.left + window.scrollX}px`,
+      top: `${buttonRect.top - menuRect.height + window.scrollY}px`
+    };
   } else {
     return styles;
   }


### PR DESCRIPTION
Adds handling for the menu colliding at the bottom, and colliding the right and the bottom. 

Let me know if you have any feedback or if I should add any examples or tests. 

Thanks for taking the time to review! 

**Bottom**
<img width="156" alt="screen shot 2018-09-03 at 7 41 44 pm" src="https://user-images.githubusercontent.com/2984336/45004350-71e97e80-afb1-11e8-8790-bb196d4b917b.png">

**Right (already included)**
<img width="173" alt="screen shot 2018-09-03 at 7 41 17 pm" src="https://user-images.githubusercontent.com/2984336/45004352-72821500-afb1-11e8-9b74-9bf2834ca73f.png">

**Right and Bottom**
<img width="179" alt="screen shot 2018-09-03 at 7 41 29 pm" src="https://user-images.githubusercontent.com/2984336/45004351-72821500-afb1-11e8-9e57-10bfd3205af0.png">

