### PR TITLE
Make checkStyles a no-op in production

### DIFF
--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,18 +1,24 @@
 let checkedPkgs = {};
 
-export let checkStyles = pkg => {
-  // only check once per package
-  if (checkedPkgs[pkg]) return;
-  checkedPkgs[pkg] = true;
+let checkStyles = () => {};
 
-  if (
-    parseInt(
-      window.getComputedStyle(document.body).getPropertyValue(`--reach-${pkg}`),
-      10
-    ) !== 1
-  ) {
-    console.warn(
-      `@reach/${pkg} styles not found. If you are using a bundler like webpack or parcel include this in the entry file of your app before any of your own styles:
+if (__DEV__) {
+  checkStyles = pkg => {
+    if (!__DEV__) return;
+    // only check once per package
+    if (checkedPkgs[pkg]) return;
+    checkedPkgs[pkg] = true;
+
+    if (
+      parseInt(
+        window
+          .getComputedStyle(document.body)
+          .getPropertyValue(`--reach-${pkg}`),
+        10
+      ) !== 1
+    ) {
+      console.warn(
+        `@reach/${pkg} styles not found. If you are using a bundler like webpack or parcel include this in the entry file of your app before any of your own styles:
 
     import "@reach/${pkg}/styles.css";
 
@@ -22,9 +28,12 @@ export let checkStyles = pkg => {
 
   For more information visit https://ui.reach.tech/styling.
   `
-    );
-  }
-};
+      );
+    }
+  };
+}
+
+export { checkStyles };
 
 export let wrapEvent = (handler, cb) => event => {
   handler && handler(event);

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -4,7 +4,6 @@ let checkStyles = () => {};
 
 if (__DEV__) {
   checkStyles = pkg => {
-    if (!__DEV__) return;
     // only check once per package
     if (checkedPkgs[pkg]) return;
     checkedPkgs[pkg] = true;


### PR DESCRIPTION
Closes #6 

Compiled output:
```
var checkedPkgs = {};

var checkStyles = function checkStyles() {};

if (process.env.NODE_ENV !== "production") {
  exports.checkStyles = checkStyles = function checkStyles(pkg) {
    if (!(process.env.NODE_ENV !== "production")) return;
    // only check once per package
    if (checkedPkgs[pkg]) return;
    checkedPkgs[pkg] = true;

    if (parseInt(window.getComputedStyle(document.body).getPropertyValue("--reach-" + pkg), 10) !== 1) {
      console.warn("@reach/" + pkg + " styles not found. If you are using a bundler like webpack or parcel include this in the entry file of your app before any of your own styles:\n\n    import \"@reach/" + pkg + "/styles.css\";\n\n  Otherwise you'll need to include them some other way:\n\n    <link rel=\"stylesheet\" type=\"text/css\" href=\"node_modules/@reach/" + pkg + "/styles.css\" />\n\n  For more information visit https://ui.reach.tech/styling.\n  ");
    }
  };
}

exports.checkStyles = checkStyles;
```