### PR TITLE
detecting rigor is better.

### DIFF
--- a/www/src/components/createMediaListener.js
+++ b/www/src/components/createMediaListener.js
@@ -25,7 +25,7 @@ export default media => {
   }, {});
 
   const notify = () => {
-    if (transientListener != null)
+    if (transientListener && typeof transientListener === "function")
       transientListener(mediaState);
   };
 


### PR DESCRIPTION
It is obvious here that 'transientListener' is a function type.