### PR TITLE
Add propTypes to `WindowSize` component

### DIFF
--- a/packages/window-size/src/index.js
+++ b/packages/window-size/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Component from "@reach/component-component";
+import { func } from "prop-types";
 
 let hasWindow = typeof window !== "undefined";
 
@@ -31,5 +32,9 @@ let WindowSize = ({ children }) => (
     render={({ state }) => children(state)}
   />
 );
+
+WindowSize.propTypes = {
+  children: func.isRequired
+};
 
 export default WindowSize;

--- a/www/src/pages/window-size.mdx
+++ b/www/src/pages/window-size.mdx
@@ -41,9 +41,9 @@ import WindowSize from "@reach/window-size";
 
 ## Props
 
-| Prop                   | Type   |
-| -----------------------| ------ |
-| [children](#children)  | func   |
+| Prop                   | Type   | Required |
+| -----------------------| ------ | -------- |
+| [children](#children)  | func   | true     |
 
 ### children
 


### PR DESCRIPTION
Tiny PR but takes us further forward with our goal to add `propTypes` to every Reach component :+1:

Helps close: #35