### PR TITLE
Remove redundant comment from VisuallyHidden

### DIFF
--- a/packages/visually-hidden/src/index.js
+++ b/packages/visually-hidden/src/index.js
@@ -11,9 +11,6 @@ let style = {
   position: "absolute"
 };
 
-// TODO: make a SkipNav component that appears when focus is received
-// this component will never be visible so if it has natively focusable
-// elements it will stay invisible.
 export default ({ children }) => {
-  return <div style={style} children={children} />
+  return <div style={style} children={children} />;
 };


### PR DESCRIPTION
TODO comment in VisuallyHidden asking for a SkipNav component to be
made. This has since been done but the comment wasn't removed