### PR TITLE
Update MenuButtonLink compatibility info

### DIFF
--- a/www/src/pages/menu-button.mdx
+++ b/www/src/pages/menu-button.mdx
@@ -387,6 +387,8 @@ You can put any type of content inside of a `<MenuItem>`.
 
 Handles linking to a different page in the menu. By default it works with Reach Router, but also accepts any other kind of Link as long as the `Link` uses the `React.forwardRef` API.
 
+Note that this reliance on `forwardRef` means, as of September 2018, `react-router`'s `<Link />` component is not compatible.
+
 Must be a direct child of a `<MenuList>`.
 
 ```jsx


### PR DESCRIPTION
Someone raised in an issue (#54) that it might just be easier if we clearly
state that `react-router`'s `<Link />` component doesn't work as of the
latest version.