### PR TITLE
Add PropTypes for AlertDialog, Dialog, and WindowSize; fix warnings in Rect example

### DIFF
--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -3,6 +3,7 @@ import Component from "@reach/component-component";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
 import { Consumer as IdConsumer } from "@reach/utils/lib/IdContext";
 import invariant from "invariant";
+import { func, bool, node } from "prop-types";
 
 let AlertDialogContext = createContext();
 
@@ -29,6 +30,15 @@ let AlertDialogOverlay = ({ leastDestructiveRef, ...props }) => (
     )}
   </IdConsumer>
 );
+
+let alertDialogPropTypes = {
+  isOpen: bool,
+  onDismiss: func,
+  leastDestructiveRef: func,
+  children: node
+};
+
+AlertDialogOverlay.propType = alertDialogPropTypes;
 
 let AlertDialogContent = ({ children, ...props }) => (
   <AlertDialogContext.Consumer>
@@ -60,6 +70,10 @@ let AlertDialogContent = ({ children, ...props }) => (
   </AlertDialogContext.Consumer>
 );
 
+AlertDialogContent.propTypes = {
+  children: node
+};
+
 let AlertDialogLabel = props => (
   <AlertDialogContext.Consumer>
     {({ labelId }) => (
@@ -81,6 +95,8 @@ let AlertDialog = ({ isOpen, onDismiss, leastDestructiveRef, ...props }) => (
     <AlertDialogContent {...props} />
   </AlertDialogOverlay>
 );
+
+AlertDialog.propType = alertDialogPropTypes;
 
 export {
   AlertDialog,

--- a/packages/dialog/src/index.js
+++ b/packages/dialog/src/index.js
@@ -3,6 +3,7 @@ import Component from "@reach/component-component";
 import Portal from "@reach/portal";
 import { checkStyles, wrapEvent } from "@reach/utils";
 import createFocusTrap from "focus-trap";
+import { func, bool } from "prop-types";
 
 let createAriaHider = dialogNode => {
   let originalValues = [];
@@ -138,5 +139,10 @@ let Dialog = ({ isOpen, onDismiss = k, ...props }) => (
     <DialogContent {...props} />
   </DialogOverlay>
 );
+
+Dialog.propTypes = {
+  isOpen: bool,
+  onDismiss: func
+};
 
 export { DialogOverlay, DialogContent, Dialog };

--- a/packages/rect/examples/basic.example.js
+++ b/packages/rect/examples/basic.example.js
@@ -8,7 +8,7 @@ export let Example = () => (
     {({ ref, rect }) => (
       <div>
         <pre>{JSON.stringify(rect, null, 2)}</pre>
-        <textarea>resize this</textarea>
+        <textarea defaultValue="resize this" />
         <span
           ref={ref}
           contentEditable

--- a/packages/rect/examples/pin.example.js
+++ b/packages/rect/examples/pin.example.js
@@ -17,7 +17,7 @@ export class Example extends React.Component {
         <Rect observe={this.state.pin}>
           {({ ref, rect }) => (
             <div>
-              <textarea>resize this</textarea>
+              <textarea defaultValue="resize this" />
               <span
                 ref={ref}
                 contentEditable

--- a/packages/window-size/src/index.js
+++ b/packages/window-size/src/index.js
@@ -1,5 +1,6 @@
 import React from "react";
 import Component from "@reach/component-component";
+import { func } from "prop-types";
 
 let hasWindow = typeof window !== "undefined";
 
@@ -31,5 +32,9 @@ let WindowSize = ({ children }) => (
     render={({ state }) => children(state)}
   />
 );
+
+WindowSize.propTypes = {
+  children: func.isRequired
+};
 
 export default WindowSize;


### PR DESCRIPTION
A small help towards the ongoing work in #35.

Also fixes warning that show up in the Rect examples.