### PR TITLE
Fixed building packages on Windows

### DIFF
--- a/shared/build-package.js
+++ b/shared/build-package.js
@@ -5,7 +5,7 @@ const prettyBytes = require("pretty-bytes");
 const gzipSize = require("gzip-size");
 const path = require("path");
 
-let pkg = path.basename(process.env.PWD);
+let pkg = path.basename(process.env.PWD || process.cwd());
 let babel = `${__dirname}/../node_modules/.bin/babel`;
 let rollup = `${__dirname}/../node_modules/.bin/rollup`;
 let rollupConfig = `${__dirname}/rollup-config.js`;


### PR DESCRIPTION
Hello!

First of all I want to say thank you for this wonderful repository!

After seeing it I wanted to contribute and help but unfortunately it was impossible on Windows since (AFAIK) `process.env.PWD` isn't set and I was receiving `undefined` value and I was unable to build packages locally.

If `process.env.PWD` is not set, we fallback to `process.cwd()` now.

Cheers

PS. 
Not sure about changes in `yarn.lock` I just installed dependencies 😕 