### PR TITLE
docs: fix skip nav css selector

### DIFF
--- a/www/src/pages/skip-nav.mdx
+++ b/www/src/pages/skip-nav.mdx
@@ -52,8 +52,8 @@ Renders a link that remains hidden until focused to skip to the main content.
 ## SkipNavLink CSS Selectors
 
 ```css
-[data-reach-skip-nav-link] {  }
-[data-reach-skip-nav-link]:focus { }
+[data-reach-skip-link] {  }
+[data-reach-skip-link]:focus { }
 ```
 
 ## SkipNavLink Props


### PR DESCRIPTION
Just found a small typo in the documentation for the skip-nav component.

(Thanks for this great repo btw :+1:)