### PR TITLE
Portal: Add container prop to allow rendering portal in a specific DOM node

### DIFF
--- a/packages/dialog/examples/container.example.js
+++ b/packages/dialog/examples/container.example.js
@@ -1,0 +1,38 @@
+import React from "react";
+import Component from "@reach/component-component";
+import "../styles.css";
+import { Dialog } from "../src/index";
+
+export let name = "Specific container element";
+
+export let Example = () => (
+  <Component
+    getRefs={() => ({
+      container: React.createRef()
+    })}
+    initialState={{ showDialog: false }}
+  >
+    {({ state, setState, refs }) => (
+      <React.Fragment>
+        <div ref={refs.container} />
+
+        <div>
+          <button onClick={() => setState({ showDialog: true })}>
+            Show Dialog
+          </button>
+
+          <Dialog container={refs.container} isOpen={state.showDialog}>
+            <button onClick={() => setState({ showDialog: false })}>
+              Close Dialog
+            </button>
+            <p>This is killer!</p>
+            <input type="text" />
+            <br />
+            <input type="text" />
+            <button>Ayyyyyy</button>
+          </Dialog>
+        </div>
+      </React.Fragment>
+    )}
+  </Component>
+);

--- a/packages/dialog/src/index.js
+++ b/packages/dialog/src/index.js
@@ -59,6 +59,7 @@ let FocusContext = React.createContext();
 let DialogOverlay = React.forwardRef(
   (
     {
+      container,
       isOpen = true,
       onDismiss = k,
       initialFocusRef,
@@ -70,7 +71,7 @@ let DialogOverlay = React.forwardRef(
   ) => (
     <Component didMount={checkDialogStyles}>
       {isOpen ? (
-        <Portal data-reach-dialog-wrapper>
+        <Portal container={container} data-reach-dialog-wrapper>
           <Component
             refs={{ overlayNode: null, contentNode: null }}
             didMount={({ refs }) => {
@@ -133,8 +134,8 @@ let DialogContent = React.forwardRef(
   )
 );
 
-let Dialog = ({ isOpen, onDismiss = k, ...props }) => (
-  <DialogOverlay isOpen={isOpen} onDismiss={onDismiss}>
+let Dialog = ({ container, isOpen, onDismiss = k, ...props }) => (
+  <DialogOverlay container={container} isOpen={isOpen} onDismiss={onDismiss}>
     <DialogContent {...props} />
   </DialogOverlay>
 );

--- a/packages/portal/examples/container.example.js
+++ b/packages/portal/examples/container.example.js
@@ -1,0 +1,48 @@
+import React from "react";
+import Component from "@reach/component-component";
+import Portal from "../src/index";
+
+export let name = "Specific container";
+
+export let Example = () => (
+  <Component getRefs={() => ({ container: React.createRef() })}>
+    {({ refs }) => (
+      <React.Fragment>
+        <div
+          ref={refs.container}
+          style={{
+            position: "absolute",
+            top: 0,
+            left: 20,
+            width: 100,
+            border: "solid 5px",
+            padding: 20,
+            background: "#f0f0f0"
+          }}
+        >
+          This is a sibling DOM node to the tree where the portal component is
+          rendered. We render the portal inside this container.
+        </div>
+
+        <div
+          style={{
+            height: 40,
+            overflow: "auto"
+          }}
+        >
+          <div style={{ border: "solid 5px", padding: 20, marginLeft: 170 }}>
+            This is in the normal react root, with an overflow hidden parent,
+            clips the box.
+          </div>
+          <Portal container={refs.container}>
+            <div style={{ border: "solid 5px" }}>
+              This is inside the portal, rendered in the DOM inside the given
+              container element so the CSS doesn't screw things up, but we
+              render it in the react hierarchy where it makes sense.
+            </div>
+          </Portal>
+        </div>
+      </React.Fragment>
+    )}
+  </Component>
+);

--- a/packages/portal/src/index.js
+++ b/packages/portal/src/index.js
@@ -2,16 +2,28 @@ import React from "react";
 import ReactDOM from "react-dom";
 import Component from "@reach/component-component";
 
-let Portal = ({ children, type = "reach-portal" }) => (
+let Portal = ({
+  children,
+  container = document.body,
+  type = "reach-portal"
+}) => (
   <Component
     getRefs={() => ({ node: null })}
     didMount={({ refs, forceUpdate }) => {
+      let containerNode = container.hasOwnProperty("current")
+        ? container.current
+        : container;
       refs.node = document.createElement(type);
-      document.body.appendChild(refs.node);
+      containerNode.appendChild(refs.node);
       forceUpdate();
     }}
     willUnmount={({ refs: { node } }) => {
-      document.body.removeChild(node);
+      let containerNode = container.hasOwnProperty("current")
+        ? container.current
+        : container;
+      if (containerNode) {
+        containerNode.removeChild(node);
+      }
     }}
     render={({ refs: { node } }) => {
       return node ? ReactDOM.createPortal(children, node) : null;


### PR DESCRIPTION
This PR is an initial take on how to address https://github.com/reach/reach-ui/issues/87

Sometimes it'd be helpful to be able to render `<Dialog />` in other DOM nodes than `document.body`. This PR enables this by allowing the user to pass a `container` prop with a React ref pointing to the DOM node that they want to render the portal containing the `<Dialog />` in.

Edit: I forgot to handle `aria-hidden`.