### PR TITLE
Allow users to override position using setPosition on the MenuList

### DIFF
--- a/packages/menu-button/examples/custom-position.example.js
+++ b/packages/menu-button/examples/custom-position.example.js
@@ -1,0 +1,29 @@
+import React from "react";
+import "../styles.css";
+import { action } from "@storybook/addon-actions";
+import { Menu, MenuList, MenuButton, MenuItem } from "../src/index";
+
+export let name = "Position";
+
+export let Example = () => (
+  <div style={{ marginLeft: 100 }}>
+    <Menu>
+      <MenuButton>
+        Actions <span aria-hidden="true">▾</span>
+      </MenuButton>
+      <MenuList setPosition={centered}>
+        <MenuItem onSelect={action("Download")}>Download</MenuItem>
+        <MenuItem onSelect={action("Copy")}>Create a Copy</MenuItem>
+        <MenuItem onSelect={action("Mark as Draft")}>Mark as Draft</MenuItem>
+        <MenuItem onSelect={action("Delete")}>Delete</MenuItem>
+      </MenuList>
+    </Menu>
+  </div>
+);
+
+let centered = (styles, { buttonRect, menuRect }) => {
+  return {
+    ...styles,
+    left: styles.left - buttonRect.width / 2
+  };
+};

--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -143,7 +143,7 @@ MenuButton.propTypes = {
 
 ////////////////////////////////////////////////////////////////////////
 
-let MenuList = props => (
+let MenuList = ({ setPosition = null, ...props }) => (
   <Consumer>
     {({ refs, state, setState }) =>
       state.isOpen && (
@@ -155,7 +155,7 @@ let MenuList = props => (
                   <div
                     data-reach-menu
                     ref={menuRef}
-                    style={getStyles(state.buttonRect, menuRect)}
+                    style={getStyles(state.buttonRect, menuRect, setPosition)}
                   >
                     <MenuListImpl
                       {...props}
@@ -175,7 +175,8 @@ let MenuList = props => (
 );
 
 MenuList.propTypes = {
-  children: node
+  children: node,
+  setPosition: func
 };
 
 let MenuListImpl = React.forwardRef(
@@ -369,10 +370,15 @@ MenuLink.propTypes = {
   _ref: func
 };
 
+let getStyles = (buttonRect, menuRect, setPosition = null) => {
+  let styles = getInitialStyles(buttonRect, menuRect);
+  return setPosition ? setPosition(styles, { buttonRect, menuRect }) : styles;
+};
+
 // TODO: Deal with collisions on the bottom, though not as important
 // since focus causes a scroll and will then scroll the page down
 // to the item.
-let getStyles = (buttonRect, menuRect) => {
+let getInitialStyles = (buttonRect, menuRect) => {
   let haventMeasuredButtonYet = !buttonRect;
   if (haventMeasuredButtonYet) {
     return { opacity: 0 };
@@ -381,8 +387,8 @@ let getStyles = (buttonRect, menuRect) => {
   let haventMeasuredMenuYet = !menuRect;
 
   let styles = {
-    left: `${buttonRect.left + window.scrollX}px`,
-    top: `${buttonRect.top + buttonRect.height + window.scrollY}px`
+    left: `${buttonRect.left + window.scrollX}`,
+    top: `${buttonRect.top + buttonRect.height + window.scrollY}`
   };
 
   if (haventMeasuredMenuYet) {
@@ -402,8 +408,8 @@ let getStyles = (buttonRect, menuRect) => {
   if (collisionRight) {
     return {
       ...styles,
-      left: `${buttonRect.right - menuRect.width + window.scrollX}px`,
-      top: `${buttonRect.top + buttonRect.height + window.scrollY}px`
+      left: `${buttonRect.right - menuRect.width + window.scrollX}`,
+      top: `${buttonRect.top + buttonRect.height + window.scrollY}`
     };
     // } else if (collisionBottom) {
   } else {


### PR DESCRIPTION
Allows users to pass a `setPosition` props to the `MenuList` components to overrides styles of the menu.

That will allow users to position the menu list wherever they want (centered, to the right of the dropdown, above, ...)

