### PR TITLE
menu-button: add `component` prop to MenuButton

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -99,57 +99,68 @@ Menu.propTypes = {
 };
 
 ////////////////////////////////////////////////////////////////////////
-let MenuButton = React.forwardRef(({ onClick, onKeyDown, ...props }, ref) => (
-  <Consumer>
-    {({ refs, state, setState }) => (
-      <Rect
-        observe={state.isOpen}
-        onChange={buttonRect => setState({ buttonRect })}
-      >
-        {({ ref: rectRef }) => (
-          <button
-            id={state.buttonId}
-            aria-haspopup="menu"
-            aria-expanded={state.isOpen}
-            data-reach-menu-button
-            type="button"
-            ref={node => {
-              rectRef(node);
-              ref && ref(node);
-              refs.button = node;
-            }}
-            onMouseDown={event => {
-              if (state.isOpen) {
-                setState({ closingWithClick: true });
-              }
-            }}
-            onClick={wrapEvent(onClick, event => {
-              if (state.isOpen) {
-                setState(close);
-              } else {
-                setState(openAtFirstItem);
-              }
-            })}
-            onKeyDown={wrapEvent(onKeyDown, event => {
-              if (event.key === "ArrowDown") {
-                event.preventDefault(); // prevent scroll
-                setState(openAtFirstItem);
-              } else if (event.key === "ArrowUp") {
-                event.preventDefault(); // prevent scroll
-                setState(openAtFirstItem);
-              }
-            })}
-            {...props}
-          />
-        )}
-      </Rect>
-    )}
-  </Consumer>
-));
+let MenuButton = React.forwardRef(
+  (
+    {
+      onClick,
+      onKeyDown,
+      asAccessibleButtonComponent: Comp = "button",
+      ...props
+    },
+    ref
+  ) => (
+    <Consumer>
+      {({ refs, state, setState }) => (
+        <Rect
+          observe={state.isOpen}
+          onChange={buttonRect => setState({ buttonRect })}
+        >
+          {({ ref: rectRef }) => (
+            <Comp
+              id={state.buttonId}
+              aria-haspopup="menu"
+              aria-expanded={state.isOpen}
+              data-reach-menu-button
+              type="button"
+              ref={node => {
+                rectRef(node);
+                ref && ref(node);
+                refs.button = node;
+              }}
+              onMouseDown={event => {
+                if (state.isOpen) {
+                  setState({ closingWithClick: true });
+                }
+              }}
+              onClick={wrapEvent(onClick, event => {
+                if (state.isOpen) {
+                  setState(close);
+                } else {
+                  setState(openAtFirstItem);
+                }
+              })}
+              onKeyDown={wrapEvent(onKeyDown, event => {
+                if (event.key === "ArrowDown") {
+                  event.preventDefault(); // prevent scroll
+                  setState(openAtFirstItem);
+                } else if (event.key === "ArrowUp") {
+                  event.preventDefault(); // prevent scroll
+                  setState(openAtFirstItem);
+                }
+              })}
+              {...props}
+            />
+          )}
+        </Rect>
+      )}
+    </Consumer>
+  )
+);
 
 MenuButton.propTypes = {
   onClick: func,
   onKeyDown: func,
+  asAccessibleButtonComponent: oneOfType([string, node]),
   children: node
 };
 

--- a/www/src/pages/menu-button.mdx
+++ b/www/src/pages/menu-button.mdx
@@ -151,12 +151,13 @@ If you'd like to target when the menu is open use `aria-expanded`:
 
 ## MenuButton Props
 
-| Prop                                     | Type                 | Required |
-| ---------------------------------------- | -------------------- | -------- |
-| [button props](#menubutton-button-props) | spread               | n/a
-| [children](#menubutton-children)         | node                 | false
-| onClick                                  | preventableEventFunc | false
-| onKeyDown                                | preventableEventFunc | false
+| Prop                                                                   | Type                 | Required |
+| ---------------------------------------------------------------------- | -------------------- | -------- |
+| [button props](#menubutton-button-props)                               | spread               | n/a
+| [asAccessibleButtonComponent](#menubutton-asaccessiblebuttoncomponent) | node | string        | false
+| [children](#menubutton-children)                                       | node                 | false
+| onClick                                                                | preventableEventFunc | false
+| onKeyDown                                                              | preventableEventFunc | false
 
 ### MenuButton button props
 
@@ -176,6 +177,19 @@ Any props not listed above will be spread onto the underlying button element. Yo
     <MenuItem onSelect={() => {}}>Do nothing</MenuItem>
   </MenuList>
 </Menu>
+```
+
+
+### MenuButton asAccessibleButtonComponent
+
+*Type*: `oneOfType(string, component)`
+
+By default, `MenuButton` renders a `button`.
+
+```.jsx
+<MenuButton asAccessibleButtonComponent={MyFancyButton}>
+  Actions <span aria-hidden>▾</span>
+</MenuButton>
 ```
 
 


### PR DESCRIPTION
Addresses https://github.com/reach/reach-ui/issues/96

> Like `MenuLink`, it would be nice to add a `component` prop on `MenuButton`. This would allow [abstractions through components] to be used with `MenuButton`.