### PR TITLE
rect: Remove prop spread down to Component

### DIFF
--- a/packages/rect/src/index.js
+++ b/packages/rect/src/index.js
@@ -34,7 +34,6 @@ let willUnmount = ({ refs }) => {
 
 let Rect = props => (
   <Component
-    {...props}
     refs={{
       node: undefined,
       observer: undefined


### PR DESCRIPTION
Noticed none of the `Rect` props: children, observe, or onChange, needed to be spread down to `Component`, so this wasn't doing anything, as far as I can tell.