### PR TITLE
[menu-button] ArrowUp after MouseLeave of non MenuItem causes runtime error

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -365,7 +365,7 @@ let MenuListImpl = React.forwardRef(
           } else if (event.key === "ArrowUp") {
             event.preventDefault(); // prevent window scroll
             let nextIndex = state.selectionIndex - 1;
-            if (nextIndex !== -1) {
+            if (nextIndex > -1) {
               setState({ selectionIndex: nextIndex });
             }
           } else if (event.key === "Tab") {


### PR DESCRIPTION
Arrowing up after mousing over/out of a non Menuitem child was setting the `selectionIndex` to values that were out of range.

To reproduce on master:

1. Open Non Menu Children in storybook 
2.  Open menu
3. Arrow to an item
4.  Mouseover and out of a non MenuItem (one of the section labels)
5.  ArrowUp
