### PR TITLE
@reach/menu-button: Fix positioning and hovering issues on IE11

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -413,7 +413,6 @@ let getStyles = (buttonRect, menuRect) => {
     left: `${buttonRect.left + window.pageXOffset}px`,
     top: `${buttonRect.top + buttonRect.height + window.pageYOffset}px`
   };
-  console.log("styles: ", styles);
 
   if (haventMeasuredMenuYet) {
     return {

--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -348,7 +348,7 @@ let MenuListImpl = React.forwardRef(
         onBlur={event => {
           if (
             !state.closingWithClick &&
-            !refs.menu.contains(event.relatedTarget)
+            !refs.menu.contains(event.relatedTarget || document.activeElement)
           ) {
             setState(close);
           }
@@ -410,9 +410,10 @@ let getStyles = (buttonRect, menuRect) => {
   let haventMeasuredMenuYet = !menuRect;
 
   let styles = {
-    left: `${buttonRect.left + window.scrollX}px`,
-    top: `${buttonRect.top + buttonRect.height + window.scrollY}px`
+    left: `${buttonRect.left + window.pageXOffset}px`,
+    top: `${buttonRect.top + buttonRect.height + window.pageYOffset}px`
   };
+  console.log("styles: ", styles);
 
   if (haventMeasuredMenuYet) {
     return {
@@ -438,11 +439,11 @@ let getStyles = (buttonRect, menuRect) => {
   return {
     ...styles,
     left: directionRight
-      ? `${buttonRect.right - menuRect.width + window.scrollX}px`
-      : `${buttonRect.left + window.scrollX}px`,
+      ? `${buttonRect.right - menuRect.width + window.pageXOffset}px`
+      : `${buttonRect.left + window.pageXOffset}px`,
     top: directionUp
-      ? `${buttonRect.top - menuRect.height + window.scrollY}px`
-      : `${buttonRect.top + buttonRect.height + window.scrollY}px`
+      ? `${buttonRect.top - menuRect.height + window.pageYOffset}px`
+      : `${buttonRect.top + buttonRect.height + window.pageYOffset}px`
   };
 };
 


### PR DESCRIPTION
Fixes #94 

This PR fixes a couple of critical issues on IE11:

## MenuList not positioned correctly

IE11 and below don't support `window.scrollX` and `window.scrollY` which results in `top: NaNpx` and same for `left`

![reach-menu-ie11-positioning-issue](https://user-images.githubusercontent.com/942863/51401604-16c0be80-1b43-11e9-88db-a7fc44685170.gif)

The fix implemented is changing to `window.pageXOffset` and `window.pageYOffset` which are supported by all browsers. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/Window/scrollX#Notes)

**After fix:**

![reach-menu-ie11-positioning-issue-fixed](https://user-images.githubusercontent.com/942863/51401846-ba11d380-1b43-11e9-8b3b-ba5799116c0c.gif)

## MenuList closes when non-selected item is hovered

IE11 and below don't support `event.relatedTarget` which results in the `onBlur` check failing incorrectly.

![reach-menu-ie11-hover-issue](https://user-images.githubusercontent.com/942863/51401964-137a0280-1b44-11e9-949a-1f95754eef9c.gif)

The fix implemented was simply to also check for `document.activeElement` too. [Read more](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/activeElement)

**After fix:**

![reach-menu-ie11-hover-issue-fixed](https://user-images.githubusercontent.com/942863/51402028-47edbe80-1b44-11e9-9016-eb7d3dceb792.gif)