### PR TITLE
Fix getFocusableMenuChildren receives non array children

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -327,9 +327,7 @@ let focusableChildrenTypes = [MenuItem, MenuLink];
 
 let isFocusableChildType = child => focusableChildrenTypes.includes(child.type);
 let getFocusableMenuChildren = children => {
-  return React.Children.toArray(children).filter(child =>
-    isFocusableChildType(child)
-  );
+  return [].concat(children).filter(child => isFocusableChildType(child));
 };
 
 let MenuListImpl = React.forwardRef(

--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -327,7 +327,9 @@ let focusableChildrenTypes = [MenuItem, MenuLink];
 
 let isFocusableChildType = child => focusableChildrenTypes.includes(child.type);
 let getFocusableMenuChildren = children => {
-  return children.filter(child => isFocusableChildType(child));
+  return React.Children.toArray(children).filter(child =>
+    isFocusableChildType(child)
+  );
 };
 
 let MenuListImpl = React.forwardRef(


### PR DESCRIPTION
This PR attempts to fix #114 

