### PR TITLE
Adding the html event (onClick or onKeyDown) as a param to DialogOverlay onDismiss

### DIFF
--- a/packages/dialog/src/index.js
+++ b/packages/dialog/src/index.js
@@ -86,12 +86,12 @@ let DialogOverlay = React.forwardRef(
                     data-reach-dialog-overlay
                     onClick={wrapEvent(onClick, event => {
                       event.stopPropagation();
-                      onDismiss();
+                      onDismiss(event);
                     })}
                     onKeyDown={wrapEvent(onKeyDown, event => {
                       if (event.key === "Escape") {
                         event.stopPropagation();
-                        onDismiss();
+                        onDismiss(event);
                       }
                     })}
                     ref={node => {

--- a/packages/rect/examples/use-rect.example.js
+++ b/packages/rect/examples/use-rect.example.js
@@ -1,5 +1,5 @@
 import React, { useRef } from "react";
-import Rect, { useRect } from "../src/index";
+import { useRect } from "../src/index";
 
 export const name = "useRect";
 

--- a/packages/tabs/examples/disabled.example.js
+++ b/packages/tabs/examples/disabled.example.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React from "react";
 import "../styles.css";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "../src";
 


### PR DESCRIPTION
I figured this was a good solution to allowing the user to conditionally invoke their dismiss prop depending on the event type that called onDismiss.  

e.g. only invoke your dismiss prop for event.type === 'keydown'

Let me know if I missed anywhere, or if I should update any examples in addition.

- Adds event as a param from onClick and onKeyDown to onDismiss callback in DialogOverlay
- Removed unused ref Rect in use-rect.exmaple
- Removed unused ref useState in disabled.example

The removal of the unused refs might be a problem with setup? it looks like in www/.eslintignore it tries to ignore ../packages. But I could not pass the --max-warnings=0 check on pre-commit without removing them.