### PR TITLE
Append portaled content to the correct (owner) document

### DIFF
--- a/packages/portal/src/index.js
+++ b/packages/portal/src/index.js
@@ -4,17 +4,25 @@ import Component from "@reach/component-component";
 
 let Portal = ({ children, type = "reach-portal" }) => (
   <Component
-    getRefs={() => ({ node: null })}
+    getRefs={() => ({ mountNode: null, portalNode: null })}
     didMount={({ refs, forceUpdate }) => {
-      refs.node = document.createElement(type);
-      document.body.appendChild(refs.node);
+      // It's possible that the content we are portal has, itself, been portaled.
+      // In that case, it's important to append to the correct document element.
+      const ownerDocument = refs.mountNode.ownerDocument;
+      refs.portalNode = ownerDocument.createElement(type);
+      ownerDocument.body.appendChild(refs.portalNode);
       forceUpdate();
     }}
-    willUnmount={({ refs: { node } }) => {
-      document.body.removeChild(node);
+    willUnmount={({ refs: { portalNode } }) => {
+      portalNode.ownerDocument.body.removeChild(portalNode);
     }}
-    render={({ refs: { node } }) => {
-      return node ? createPortal(children, node) : null;
+    render={({ refs }) => {
+      const { portalNode } = refs;
+      if (!portalNode) {
+        return <div ref={div => (refs.mountNode = div)} />;
+      } else {
+        return createPortal(children, portalNode);
+      }
     }}
   />
 );


### PR DESCRIPTION
This afternoon I tried plugging the `MenuButton` component into the new React DevTools (https://github.com/bvaughn/react-devtools-experimental/pull/108) but I ran into a snag. The DevTools extension portals itself into Chrome panels, but the Reach `Portal` component assumes its content should be appended to the root/original `document`. The result is that the `MenuButton` portal (and others) are essentially invisible.

This PR fixes that. Posting for discussion purposes! 🙇

cc @ryanflorence