### PR TITLE
Fix conditionally-rendered MenuItem in MenuList

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -376,7 +376,7 @@ let MenuListImpl = React.forwardRef(
           }
         })}
       >
-        {Children.map(children, (child, index) => {
+        {Children.map(Children.toArray(children), (child, index) => {
           if (isFocusableChildType(child)) {
             let focusIndex = focusableChildren.indexOf(child);
 


### PR DESCRIPTION
This PR fixes conditionally-rendered menu items causing crashes when MenuList attempts to focus null children. Issue resolved by passing children through Children.toArray, which filters out null elements. 

Resolves #121 