### PR TITLE
Declare type definition for @reach/auto-id

### DIFF
--- a/packages/auto-id/index.d.ts
+++ b/packages/auto-id/index.d.ts
@@ -1,0 +1,3 @@
+declare module "@reach/auto-id" {
+  const useId: () => number;
+}


### PR DESCRIPTION
Nothing fancy going on here!

I'd just love to be able to use this package in a typescript project without writing a separate typedef.  :)