### PR TITLE
Lift menu list class name to outer div

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -287,7 +287,7 @@ MenuLink.propTypes = {
 };
 ///////////////////////////////////////////////////////////////////
 
-let MenuList = React.forwardRef((props, ref) => (
+let MenuList = React.forwardRef(({ className, ...props }, ref) => (
   <Consumer>
     {({ refs, state, setState }) =>
       state.isOpen && (
@@ -298,6 +298,7 @@ let MenuList = React.forwardRef((props, ref) => (
                 {({ rect: menuRect, ref: menuRef }) => (
                   <div
                     data-reach-menu
+                    className={className}
                     ref={menuRef}
                     style={getStyles(state.buttonRect, menuRect)}
                   >


### PR DESCRIPTION
**Note:** Breaking Change

Because the `data-reach-menu` element is rendered in a portal, there's no way (that I'm aware of) to scope styles specifically to one menu. I can style `data-reach-menu`, but only globally. 

![Screen Shot 2019-04-22 at 8 38 17 PM](https://user-images.githubusercontent.com/2984336/56546020-f556e080-653e-11e9-8037-380324b6731e.png)


Maybe I'm missing something there? 

What this does is lift the `className` from `MenuList` to that outer div. This does present some naming issues, as it seems odd to have the class name from `MenuList` style the `data-reach-menu` element. 

Any thoughts? 