### PR TITLE
Publish menu-button type definitions

### DIFF
--- a/packages/menu-button/package.json
+++ b/packages/menu-button/package.json
@@ -5,6 +5,7 @@
   "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "main": "index.js",
+  "types": "index.d.ts",
   "module": "es/index.js",
   "scripts": {
     "test": "echo \"Write some tests you bum!\"",

--- a/packages/menu-button/package.json
+++ b/packages/menu-button/package.json
@@ -39,6 +39,7 @@
     "src",
     "lib",
     "index.js",
+    "index.d.ts",
     "styles.css"
   ]
 }


### PR DESCRIPTION
The type definitions added in #92 were not published with the npm package. 😄