### PR TITLE
Account for possible scrollbars in the Tooltip triangle sample

### DIFF
--- a/packages/tooltip/examples/triangle.example.js
+++ b/packages/tooltip/examples/triangle.example.js
@@ -9,7 +9,8 @@ export const name = "Triangle";
 const centered = (triggerRect, tooltipRect) => {
   const triggerCenter = triggerRect.left + triggerRect.width / 2;
   const left = triggerCenter - tooltipRect.width / 2;
-  const maxLeft = window.innerWidth - tooltipRect.width - 2;
+  // 17px is the max width of possible scrollbars on various platforms
+  const maxLeft = window.innerWidth - tooltipRect.width - 17;
   return {
     left: Math.min(Math.max(2, left), maxLeft) + window.scrollX,
     top: triggerRect.bottom + 8 + window.scrollY


### PR DESCRIPTION
Okay, this might seem kinda dumb but a common thing with tooltips in my experience: on platforms where scrollbars are visible the tooltip causes scrollbars to appear if the tooltip is too close to the said scrollbar:

![image](https://user-images.githubusercontent.com/7641760/56931041-56565980-6ae7-11e9-8499-47256fa533d1.png)

Deducting the [common max of scrollbar widths](https://codepen.io/sambible/post/browser-scrollbar-widths) from `maxLeft` removes the issue:

![image](https://user-images.githubusercontent.com/7641760/56931105-8d2c6f80-6ae7-11e9-92e5-b6e305b2968c.png)

And the tooltips that don't touch the scrollbar still work as expected:

![image](https://user-images.githubusercontent.com/7641760/56931239-062bc700-6ae8-11e9-82ca-c81af7ed318a.png)


