### PR TITLE
Menu button space fix

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -204,6 +204,9 @@ let MenuItem = React.forwardRef(
             // this "Enter" keydown
             event.preventDefault();
             select();
+          } else if (event.key === " ") {
+            event.preventDefault();
+            select();
           }
         })}
         onMouseMove={wrapEvent(onMouseMove, event => {

--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -199,12 +199,9 @@ let MenuItem = React.forwardRef(
           select();
         })}
         onKeyDown={wrapEvent(onKeyDown, event => {
-          if (event.key === "Enter") {
+          if (event.key === "Enter" || event.key === " ") {
             // prevent the button from being "clicked" by
             // this "Enter" keydown
-            event.preventDefault();
-            select();
-          } else if (event.key === " ") {
             event.preventDefault();
             select();
           }


### PR DESCRIPTION
This is a fix for the [issue #100 ](https://github.com/reach/reach-ui/issues/99).

1. Stop the default behavior i.e. scrolling.
2. Select the current item. 