### PR TITLE
Simplify Tooltip statechat management

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -144,11 +144,10 @@ function transition(action, newContext) {
 
   // Really useful for debugging
   // console.log({ action, state, nextState, contextId: context.id });
+  // !nextState && console.log('no transition taken')
 
   if (!nextState) {
-    throw new Error(
-      `Unknown state for action "${action}" from state "${state}"`
-    );
+    return;
   }
 
   if (stateDef.leave) {
@@ -262,74 +261,37 @@ export function useTooltip({
   useEffect(() => checkStyles("tooltip"));
 
   const handleMouseEnter = () => {
-    switch (state) {
-      case IDLE:
-      case VISIBLE:
-      case LEAVING_VISIBLE: {
-        transition("mouseenter", { id });
-      }
-    }
+    transition("mouseenter", { id });
   };
 
   const handleMouseMove = () => {
-    switch (state) {
-      case FOCUSED: {
-        transition("mousemove", { id });
-      }
-    }
+    transition("mousemove", { id });
   };
 
   const handleFocus = event => {
     if (shouldIgnoreTooltips()) return;
-    switch (state) {
-      case IDLE:
-      case VISIBLE:
-      case LEAVING_VISIBLE: {
-        transition("focus", { id });
-      }
-    }
+    transition("focus", { id });
   };
 
   const handleMouseLeave = () => {
-    switch (state) {
-      case FOCUSED:
-      case VISIBLE:
-      case DISMISSED: {
-        transition("mouseleave");
-      }
-    }
+    transition("mouseleave");
   };
 
   const handleBlur = () => {
     // Allow quick click from one tool to another
     if (context.id !== id) return;
-    switch (state) {
-      case FOCUSED:
-      case VISIBLE:
-      case DISMISSED: {
-        transition("blur");
-      }
-    }
+    transition("blur");
   };
 
   const handleMouseDown = () => {
     // Allow quick click from one tool to another
     if (context.id !== id) return;
-    switch (state) {
-      case FOCUSED:
-      case VISIBLE: {
-        transition("mousedown");
-      }
-    }
+    transition("mousedown");
   };
 
   const handleKeyDown = event => {
     if (event.key === "Enter" || event.key === " ") {
-      switch (state) {
-        case VISIBLE: {
-          transition("selectWithKeyboard");
-        }
-      }
+      transition("selectWithKeyboard");
     }
   };
 


### PR DESCRIPTION
By definition statecharts ignore events for which they don't have defined transitions on the active state node. So it seems to me this is counterproductive to guard against "undefined" transitions at the event dispatch site. Main reason for that is that whenever you want to tweak your statechart definition you'd have to tweak your transition call sites too
