### PR TITLE
Fix missing Auto ID page on documentation website

### DIFF
--- a/www/src/pages/auto-id.mdx
+++ b/www/src/pages/auto-id.mdx
@@ -1,0 +1,31 @@
+import Helmet from "react-helmet"
+
+<Helmet
+  title="Reach UI - Auto ID"
+  meta={[
+    {
+      name: "description",
+      content: "Autogenerate IDs to facilitate WAI-ARIA and server rendering.",
+    },
+  ]}
+/>
+
+# Auto ID
+
+Autogenerate IDs to facilitate WAI-ARIA and server rendering.
+
+## Installation
+
+```bash
+npm install @reach/auto-id
+# or
+yarn add @reach/auto-id
+```
+
+## Usage
+
+```js
+import { useId } from "@reach/auto-id"
+
+const id = `tooltip:${useId()}`
+```


### PR DESCRIPTION
Right now there's an `Auto ID` menu at https://ui.reach.tech/, which will lead to https://ui.reach.tech/auto-id, and show the `NOT FOUND` page.

This PR adds a page for `Auto ID` (`@reach/auto-id`) and fix that issue.