### PR TITLE
improve useId

### DIFF
--- a/packages/auto-id/src/index.js
+++ b/packages/auto-id/src/index.js
@@ -9,7 +9,6 @@ let id = 0;
 const genId = () => ++id;
 
 export const useId = () => {
-  const [id, setId] = useState(null);
-  useEffect(() => setId(genId()), []);
+  const [id] = useState(genId);
   return id;
 };


### PR DESCRIPTION
useEffect runs after first render, so there will be no id on the first render and then second render will be triggered right after the first one due to `setId`. Instead we can use generator function in useState

`const genId = () => ++id;` is not server friendly, we can use [nanoid](https://github.com/ai/nanoid) (141 bytes) to make it server friendly. I can make PR if you want




