### PR TITLE
Fix scrolling issue for Tabs

### DIFF
--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -131,17 +131,15 @@ export const TabList = forwardRef(function TabList(
         _onSelectTab(nextIndex);
         break;
       }
-      case "ArrowDown": {
-        // don't scroll down
-        event.preventDefault();
-        _onFocusPanel();
-        break;
-      }
       case "Home": {
+        // don't scroll up
+        event.preventDefault();
         _onSelectTab(0);
         break;
       }
       case "End": {
+        // don't scroll down
+        event.preventDefault();
         _onSelectTab(React.Children.count(children) - 1);
         break;
       }


### PR DESCRIPTION
Don't override up/down arrow, because user can easily undo/redo thi action.
Prevent default behaviour for Home/End so that browser doesn't scroll.