### PR TITLE
Handle left collision with a wide MenuList

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -451,7 +451,7 @@ let getStyles = (buttonRect, menuRect) => {
     top: buttonRect.top - menuRect.height < 0,
     right: window.innerWidth < buttonRect.left + menuRect.width,
     bottom: window.innerHeight < buttonRect.top + menuRect.height,
-    left: buttonRect.left - menuRect.width < 0
+    left: buttonRect.left + buttonRect.width - menuRect.width < 0
   };
 
   const directionRight = collisions.right && !collisions.left;


### PR DESCRIPTION
`@reach/menu-button` has an odd behaviour when the `MenuButton` and/or `MenuList` are wide. See the bug in action:

<details>
<summary>GIF</summary>

![patched](https://user-images.githubusercontent.com/3297808/58778238-241fa680-8615-11e9-8488-9ac5ff2d1aac.gif)


</details>

In (other) words, when the list is wider than the button the layout algorithm always assumes that a collision with the left side has occured. This works fine for left aligned menus, but not so much for right aligned ones. Since the list is not wider than the viewport there is enough space to expand it to the left.

Sandboxes are worth 1000 words, so I created [this one][sandbox] to play around in.

[sandbox]: https://codesandbox.io/s/misty-darkness-zjepf

