### PR TITLE
Fix border styles of <ComboBox/> pink demo

### DIFF
--- a/www/src/components/app.css
+++ b/www/src/components/app.css
@@ -285,7 +285,8 @@ button#hamburger {
 }
 
 .pink [data-reach-combobox-popover] {
-  border: none;
+  border: solid 1px #ccc;
+  border-top: none;
   box-sizing: border-box;
   position: relative;
   top: -1px;
@@ -310,6 +311,10 @@ button#hamburger {
 .pink[data-reach-combobox]:focus-within {
   border: solid 1px rgb(234, 89, 111);
   box-shadow: 0px 0px 2px rgb(234, 89, 111);
+}
+
+.pink[data-reach-combobox]:focus-within [data-reach-combobox-popover] {
+  border-color: transparent;
 }
 
 .pink [data-reach-combobox-input]:focus {


### PR DESCRIPTION
Without this, if we land focus outside of the browser tab instead of on another element when bluring then we'll see such broken styling:

<img width="864" alt="Screen Shot 2019-06-08 at 20 45 54" src="https://user-images.githubusercontent.com/9800850/59151189-0d22ef00-8a2f-11e9-959e-ac98a11ffcfb.png">
