### PR TITLE
prevent all tooltips from showing initially based on global state

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -10,7 +10,7 @@
 //
 // Only one tooltip can be visible at a time, so we use a global state chart to
 // describe the various states and transitions between states that are
-// possible.  With the all the timeouts involved with tooltips it's important to
+// possible. With the all the timeouts involved with tooltips it's important to
 // "make impossible states impossible" with a state machine.
 //
 // It's also okay to use these module globals because you don't server render

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -237,14 +237,14 @@ export function useTooltip({
   ref,
   DEBUG_STYLE
 } = {}) {
+  const id = `tooltip:${useId()}`;
   const [isVisible, setIsVisible] = useState(
-    DEBUG_STYLE ? true : state === VISIBLE
+    DEBUG_STYLE ? true : context.id === id && state === VISIBLE
   );
 
   // hopefully they always pass a ref if they ever pass one
   const triggerRef = ref || useRef();
   const triggerRect = useRect(triggerRef, isVisible);
-  const id = `tooltip:${useId()}`;
 
   useEffect(() => {
     return subscribe(() => {


### PR DESCRIPTION
Given #166, there is an issue of new Tooltips being shown by default if the current global state happens to be true for any other Tooltip (as there is a single state container for ALL Tooltips in an application).

This patch addresses that problem by only recovering the global state if the ID of the new usage of `useTooltip` has the same ID as the currently active ID.

However, #166's use case does still present an interesting issue, even after this patch. Having the default state be based on the ID of the Tooltip can lead to false positives as IDs are reused within the life of the the Application. Meaning that Tooltips that aren't actually meant to be shown as active appear as active. Although, this may be better to file as a separate issue.