### PR TITLE
[Tooltip] Fix invalid aria-describedby attribute 

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -333,8 +333,7 @@ export function useTooltip({
     }
   };
 
-  const trigger = {
-    "aria-describedby": id,
+  let trigger = {
     "data-reach-tooltip-trigger": "",
     ref: triggerRef,
     onMouseEnter: wrapEvent(onMouseEnter, handleMouseEnter),
@@ -345,6 +344,10 @@ export function useTooltip({
     onKeyDown: wrapEvent(onKeyDown, handleKeyDown),
     onMouseDown: wrapEvent(onMouseDown, handleMouseDown)
   };
+
+  if (isVisible) {
+    trigger["aria-describedby"] = id;
+  }
 
   const tooltip = {
     id,


### PR DESCRIPTION
## Issue
After implementing tooltips, I ran into the same Lighthouse `[aria-*] attributes do not have valid values` audit warnings referenced in [this issue](https://github.com/reach/reach-ui/issues/158), but for the `aria-describedby` attribute.

Lighthouse audit:

<img width="761" alt="Screen Shot 2019-06-14 at 12 43 38 AM" src="https://user-images.githubusercontent.com/11481550/59484111-772c0180-8e3e-11e9-86be-96926c589027.png">

Affected component:

<img width="756" alt="Screen Shot 2019-06-14 at 12 51 13 AM" src="https://user-images.githubusercontent.com/11481550/59484131-86ab4a80-8e3e-11e9-93e5-6c4f781be45c.png">

## Fix
The `aria-describedby` attribute is considered invalid if the tooltip is not visible, since the id referenced does not yet exist on the page. By showing the `aria-describedby` attribute only when the tooltip is visible, we will ensure that the attribute is valid. 

This fixed the Lighthouse warning for my tooltip implementation and raised the overall page accessibility score from 84 to 86.
