### PR TITLE
useLayoutEffect deps

### DIFF
--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -349,7 +349,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
   useLayoutEffect(() => {
     autocompletePropRef.current = autocomplete;
-  });
+  }, [autocomplete]);
 
   const handleValueChange = value => {
     if (value.trim() === "") {
@@ -654,7 +654,7 @@ function useFocusManagement(lastActionType, inputRef) {
     ) {
       inputRef.current.focus();
     }
-  });
+  }, [lastActionType]);
 }
 
 // We want the same events when the input or the popup have focus (HOW COOL ARE


### PR DESCRIPTION
Not sure if this is an actual issue, but https://github.com/kentcdodds/stop-runaway-react-effects is throwing for these as they run on each render.

I figure it doesn't hurt to have them only fire when needed?