### PR TITLE
Make @reach/dialog responsive

### DIFF
--- a/packages/dialog/styles.css
+++ b/packages/dialog/styles.css
@@ -23,7 +23,7 @@
   outline: none;
 }
 
-@media (screen and min-width: 750px) {
+@media screen and (min-width: 750px) {
   [data-reach-dialog-content] {
     width: 50vw;
   }

--- a/packages/dialog/styles.css
+++ b/packages/dialog/styles.css
@@ -16,9 +16,15 @@
 }
 
 [data-reach-dialog-content] {
-  width: 50vw;
+  width: 90vw;
   margin: 10vh auto;
   background: white;
   padding: 2rem;
   outline: none;
+}
+
+@media (screen and min-width: 750px) {
+  [data-reach-dialog-content] {
+    width: 50vw;
+  }
 }


### PR DESCRIPTION
50vw on mobile and tablet screens is not great, dialogs should be way bigger there. This switches from 90vw to 50vw on devices bigger than tablets (at least according to the media queries in `skeleton.css` for the website)