### PR TITLE
[Combobox] Add index to uniquely identify duplicate options.

### DIFF
--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -166,7 +166,7 @@ function reducer(data, action) {
     case SELECT_WITH_KEYBOARD:
       return {
         ...nextState,
-        value: data.navigationValue,
+        value: stripIndex(data.navigationValue),
         navigationValue: null
       };
     case CLOSE_WITH_BUTTON:


### PR DESCRIPTION
Devs shouldn't be providing duplicate options for users to choose from, but with this we can at least keep trucking along without running into the issue described in #216

With this change, we could also remove the need for running the hashing function to track the active descendant, but I'll leave that up to you.