### PR TITLE
Fix to allow storybook build and view in IE11

### DIFF
--- a/packages/dialog/examples/dropdown.example.js
+++ b/packages/dialog/examples/dropdown.example.js
@@ -1,6 +1,6 @@
 import React from "react";
 import Component from "@reach/component-component";
-import { Menu, MenuButton, MenuList, MenuItem } from "@reach/menu-button";
+import { Menu, MenuButton, MenuList, MenuItem } from "../../menu-button";
 import "../styles.css";
 import { Dialog } from "../src/index";
 

--- a/packages/menu-button/examples/with-tooltip.example.js
+++ b/packages/menu-button/examples/with-tooltip.example.js
@@ -4,7 +4,7 @@ import React from "react";
 import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "../src/index";
-import Tooltip from "@reach/tooltip";
+import Tooltip from "../../tooltip";
 
 export let name = "With Tooltip";
 

--- a/packages/tooltip/examples/animated.example.js
+++ b/packages/tooltip/examples/animated.example.js
@@ -2,7 +2,8 @@
 import "../styles.css";
 import React, { Fragment, cloneElement } from "react";
 import { useTooltip, TooltipPopup } from "../src/index";
-import { useTransition, animated } from "react-spring";
+// https://github.com/react-spring/react-spring/issues/552#issuecomment-464680114
+import { useTransition, animated } from "react-spring/web.cjs";
 
 export const name = "Animated";
 


### PR DESCRIPTION
When attempting to build storybook to confirm the IE 11 fix in #205, I encountered some issues.

Fixes
 - Unavailable module error when building storybook examples
 - Pulls in CommonJS build of React Spring for IE11 support