### PR TITLE
fixed tooltip collision with right side of screen

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -503,7 +503,7 @@ const getStyles = (position, triggerRect, tooltipRect) => {
 const positionDefault = (triggerRect, tooltipRect) => {
   const collisions = {
     top: triggerRect.top - tooltipRect.height < 0,
-    right: window.innerWidth < triggerRect.left + tooltipRect.width,
+    right: document.documentElement.clientWidth < triggerRect.left + tooltipRect.width,
     bottom:
       window.innerHeight < triggerRect.bottom + tooltipRect.height + OFFSET,
     left: triggerRect.left - tooltipRect.width < 0


### PR DESCRIPTION
window.innerWidth includes the width of the scrollbar.
document.documentElement.clientWidth excludes the scrollbar.