### PR TITLE
[menu-buton] ignore `null`, `false` and `undefined` <MenuList /> children

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -346,7 +346,8 @@ MenuList.propTypes = {
 
 let focusableChildrenTypes = [MenuItem, MenuLink];
 
-let isFocusableChildType = child => focusableChildrenTypes.includes(child.type);
+let isFocusableChildType = child =>
+  child != null && focusableChildrenTypes.includes(child.type);
 let getFocusableMenuChildren = children => {
   let focusable = [];
   Children.forEach(children, child => {


### PR DESCRIPTION
The PR fixes https://github.com/reach/reach-ui/issues/236.

The `null` and `undefined` values are caught by the `isFocusableChildType` check. If the child of a `<MenuList />` is `false`, `React.children` converts it to a `null`, so that case is implicitly handled.