### PR TITLE
[dialog] Pass a "reason" to onDismiss called from DialogOverlay

### DIFF
--- a/packages/dialog/src/index.js
+++ b/packages/dialog/src/index.js
@@ -87,12 +87,12 @@ let DialogOverlay = React.forwardRef(
                     data-reach-dialog-overlay
                     onClick={wrapEvent(onClick, event => {
                       event.stopPropagation();
-                      onDismiss();
+                      onDismiss("overlayClick");
                     })}
                     onKeyDown={wrapEvent(onKeyDown, event => {
                       if (event.key === "Escape") {
                         event.stopPropagation();
-                        onDismiss();
+                        onDismiss("escapeKeyDown");
                       }
                     })}
                     ref={node => {


### PR DESCRIPTION
Issue: When using DialogOverlay , there is no way to differentiate why onDismiss has been called because the ESC key was pressed, or the user clicked the overlay.

Solution: Pass a reason ("overlayClick" | "escapeKeyDown"), like how material-ui does, when calling the onDismiss. This allows the onDismiss function to have the option to have conditional logic based on the reason for dismissal.