### PR TITLE
Add note about removing CSS warning

### DIFF
--- a/www/src/pages/styling.mdx
+++ b/www/src/pages/styling.mdx
@@ -101,7 +101,6 @@ let YourMenuList = styled(MenuList)`
 ```
 
 
-
 ## CSS Selectors
 
 Because Reach UI uses regular stylesheets for its own styles you can override them like any other element. All styles use the lowest possible "specificity score", so as long as you include the component styles before your own app styles you should not run into any specificity problems.

--- a/www/src/pages/styling.mdx
+++ b/www/src/pages/styling.mdx
@@ -19,11 +19,23 @@ Styling a Reach component feels similar to styling any native element. There are
 
 # Including Base Styles
 
-Reach UI uses stylesheets for the components' base styles. You must include these styles in your app for the components to work properly
+Reach UI uses stylesheets for the components' base styles. You must include these styles in your app for the components to work properly.
 
 ## Automatically Including Styles
 
 A webpack plugin is in development that will automatically bundle the styles so you don't have to.
+
+## Skip including styles
+
+Normally, you'll receive a warning when you forget to include the matching CSS file. If you're implementing all styles yourself, you can disable this warning by setting a root CSS variable matching the package name to 1. Here's an example:
+
+```css
+:root {
+  --reach-dialog: 1;
+}
+```
+
+Note that you should tread carefully - in most cases, the styles you import are better to override than remove completely.
 
 ## Using a Bundler (webpack, parcel, etc.)
 
@@ -87,6 +99,8 @@ let YourMenuList = styled(MenuList)`
 // glamor CSS prop
 <MenuList css={absolutely}/>
 ```
+
+
 
 ## CSS Selectors
 

--- a/www/src/pages/styling.mdx
+++ b/www/src/pages/styling.mdx
@@ -27,15 +27,17 @@ A webpack plugin is in development that will automatically bundle the styles so 
 
 ## Skip including styles
 
-Normally, you'll receive a warning when you forget to include the matching CSS file. If you're implementing all styles yourself, you can disable this warning by setting a root CSS variable matching the package name to 1. Here's an example:
+Normally, you'll receive a warning when you forget to include the matching CSS file. If you're implementing all styles yourself, you can disable this warning by setting a root CSS variable matching the package name to 1.
+
+**Please tread carefully** - in most cases, the styles you import are better to override than remove completely.
+
+Here's an example:
 
 ```css
 :root {
   --reach-dialog: 1;
 }
 ```
-
-Note that you should tread carefully - in most cases, the styles you import are better to override than remove completely.
 
 ## Using a Bundler (webpack, parcel, etc.)
 


### PR DESCRIPTION
This commit adds a note about how you can remove the warning of a missing CSS file, if you want to implement the required styles yourself.

Fixes #244 