### PR TITLE
[menu-button] Count links as part of the menu when using NVDA

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -211,7 +211,7 @@ export const MenuItem = forwardRef(function MenuItem(
       ref={ref}
       data-reach-menu-item={role === "menuitem" ? true : undefined}
       role={role}
-      tabIndex={-1}
+      tabIndex={role === "menuitem" ? "-1" : undefined}
       data-selected={role === "menuitem" && isSelected ? true : undefined}
       onClick={wrapEvent(onClick, event => {
         select();


### PR DESCRIPTION
Fixes https://github.com/reach/reach-ui/issues/2

By reading https://www.w3.org/TR/wai-aria-practices-1.1/examples/menu-button/menu-button-links.html I learned that when add a `role="menuitem"` the semantics (not sure what that means yet) of descendants of the `role="menuitem"` element are not available in the accessibility tree. I'm presuming that is the cause for the NVDA not recognizing there is another element. 

You can checkout the branch and test it out on the `withLink` examples. Now it's announcing the link element as 2/3 elements in the menu. 

A side question to this: Do you you think `role` should be exposed to the outside api, since I'm not sure if any other roles other than `menuitem` and `none` makes sense for the `<MenuItem/>`.