### PR TITLE
Update docs to use hooks

### DIFF
--- a/www/src/pages/alert-dialog.mdx
+++ b/www/src/pages/alert-dialog.mdx
@@ -31,47 +31,42 @@ Every dialog must render an `AlertDialogLabel` so the screen reader knows what t
 
 This is built on top of [Dialog](/dialog), so `AlertDialog` spreads its props and renders a `Dialog`, same for `AlertDialogOverlay` to `DialogOverlay`, and `AlertDialogContent` to `DialogContent`.
 
-```jsx
-;() => {
-  class App extends React.Component {
-    constructor() {
-      super()
-      this.cancelRef = React.createRef()
-      this.state = { showDialog: false }
-      this.open = () => this.setState({ showDialog: true })
-      this.close = () => this.setState({ showDialog: false })
-    }
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const cancelRef = React.useRef();
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
 
-    render() {
-      return (
-        <div>
-          <button onClick={this.open}>Delete something</button>
+  return (
+    <div>
+      <button onClick={open}>
+        Delete something
+      </button>
 
-          {this.state.showDialog && (
-            <AlertDialog leastDestructiveRef={this.cancelRef}>
-              <AlertDialogLabel>Please Confirm!</AlertDialogLabel>
+      {showDialog && (
+        <AlertDialog leastDestructiveRef={cancelRef}>
+          <AlertDialogLabel>Please Confirm!</AlertDialogLabel>
 
-              <AlertDialogDescription>
-                Are you sure you want to delete something? This action is
-                permanent, and we're totally not just flipping a field called
-                "deleted" to "true" in our database, we're actually deleting
-                something.
-              </AlertDialogDescription>
+          <AlertDialogDescription>
+            Are you sure you want to delete something? This action
+            is permanent, and we're totally not just flipping a
+            field called "deleted" to "true" in our database, we're
+            actually deleting something.
+          </AlertDialogDescription>
 
-              <div className="alert-buttons">
-                <button onClick={this.close}>Yes, delete</button>{" "}
-                <button ref={this.cancelRef} onClick={this.close}>
-                  Nevermind, don't delete.
-                </button>
-              </div>
-            </AlertDialog>
-          )}
-        </div>
-      )
-    }
-  }
-
-  return <App />
+          <div className="alert-buttons">
+            <button onClick={close}>
+              Yes, delete
+            </button>{" "}
+            <button ref={cancelRef} onClick={close}>
+              Nevermind, don't delete.
+            </button>
+          </div>
+        </AlertDialog>
+      )}
+    </div>
+  )
 }
 ```
 
@@ -168,57 +163,59 @@ When the user clicks outside the modal or hits the escape key, this function wil
 
 **IMPORTANT**: Ensure that `onDismiss` and the click handler of the `leastDestructiveRef` are identical!
 
-```jsx
-;() => {
-  class App extends React.Component {
-    constructor() {
-      super()
-      this.cancelRef = React.createRef()
-      this.state = { confirmDelete: false }
-      this.open = () => this.setState({ confirmDelete: true })
-      this.destroyStuff = () => {
-        console.log("destroyed!")
-        this.setState({ confirmDelete: false })
-      }
-      // make sure `onDismiss` and the `onClick` of the
-      // `leastDestructiveRef` are identical, best to just
-      // pass them both the same function
-      this.onDismiss = () => this.setState({ confirmDelete: false })
-    }
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const cancelRef = React.useRef();
 
-    render() {
-      return (
-        <div>
-          <button onClick={this.open}>Delete something</button>
+  const open = () => setShowDialog(true);
+  const destroyStuff = () => {
+    console.log('Destroyed!');
+    setShowDialog(false);
+  };
+  // make sure `close` and the `onClick` of the
+  // `leastDestructiveRef` are identical, best to just
+  // pass them both the same function
+  const close = () => setShowDialog(false);
 
-          {this.state.confirmDelete && (
-            <AlertDialog
-              onDismiss={this.onDismiss}
-              leastDestructiveRef={this.cancelRef}
+  return (
+    <div>
+      <button onClick={open}>
+        Delete something
+      </button>
+
+      {showDialog && (
+        <AlertDialog
+          onDismiss={close}
+          leastDestructiveRef={cancelRef}
+        >
+          <AlertDialogLabel>
+            Please Confirm!
+          </AlertDialogLabel>
+
+          <AlertDialogDescription>
+            Are you sure you want to delete something?
+            This action is permanent, and we're totally
+            not just flipping a field called "deleted"
+            to "true" in our database, we're actually
+            deleting something.
+          </AlertDialogDescription>
+
+          <div className="alert-buttons">
+            <button onClick={destroyStuff}>
+              Yes, delete
+            </button>{" "}
+            <button
+              ref={cancelRef}
+              onClick={close}
             >
-              <AlertDialogLabel>Please Confirm!</AlertDialogLabel>
-
-              <AlertDialogDescription>
-                Are you sure you want to delete something? This action is
-                permanent, and we're totally not just flipping a field called
-                "deleted" to "true" in our database, we're actually deleting
-                something.
-              </AlertDialogDescription>
-
-              <div className="alert-buttons">
-                <button onClick={this.destroyStuff}>Yes, delete</button>{" "}
-                <button ref={this.cancelRef} onClick={this.onDismiss}>
-                  Nevermind, don't delete.
-                </button>
-              </div>
-            </AlertDialog>
-          )}
-        </div>
-      )
-    }
-  }
-
-  return <App />
+              Nevermind, don't delete.
+            </button>
+          </div>
+        </AlertDialog>
+      )}
+    </div>
+  )
 }
 ```
 
@@ -228,49 +225,50 @@ _Type_: `node`
 
 To prevent accidental data loss, an alert dialog should focus the least destructive action button when it opens.
 
-```jsx
-;() => {
-  class App extends React.Component {
-    constructor() {
-      super()
-      // we'll pass this ref to both AlertDialog and our button
-      this.cancelRef = React.createRef()
-      this.state = { confirm: false }
-      this.open = () => this.setState({ confirm: true })
-      this.publish = () => this.setState({ confirm: false })
-      this.onDismiss = () => this.setState({ confirm: false })
-    }
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
 
-    render() {
-      return (
-        <div>
-          <button onClick={this.open}>Publish something</button>
+  // we'll pass this ref to both AlertDialog and our button
+  const cancelRef = React.useRef();
 
-          {this.state.confirm && (
-            <AlertDialog leastDestructiveRef={this.cancelRef}>
-              <AlertDialogLabel>Please Confirm!</AlertDialogLabel>
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
 
-              <AlertDialogDescription>
-                Are you sure you want to publish this thing?
-              </AlertDialogDescription>
+  return (
+    <div>
+      <button onClick={open}>
+        Publish something
+      </button>
 
-              <div className="alert-buttons">
-                <button onClick={this.publish}>
-                  Yes, publish and keep editing
-                </button>{" "}
-                <button onClick={this.publish}>Yes, publish and view</button>{" "}
-                <button ref={this.cancelRef} onClick={this.onDismiss}>
-                  Don't publish, keep working
-                </button>
-              </div>
-            </AlertDialog>
-          )}
-        </div>
-      )
-    }
-  }
+      {showDialog && (
+        <AlertDialog leastDestructiveRef={cancelRef}>
+          <AlertDialogLabel>
+            Please Confirm!
+          </AlertDialogLabel>
 
-  return <App />
+          <AlertDialogDescription>
+            Are you sure you want to publish this thing?
+          </AlertDialogDescription>
+
+          <div className="alert-buttons">
+            <button onClick={this.close}>
+              Yes, publish and keep editing
+            </button>{" "}
+            <button onClick={this.close}>
+              Yes, publish and view
+            </button>{" "}
+            <button
+              ref={cancelRef}
+              onClick={close}
+            >
+              Don't publish, keep working
+            </button>
+          </div>
+        </AlertDialog>
+      )}
+    </div>
+  );
 }
 ```
 
@@ -291,7 +289,7 @@ Accepts any renderable content but should generally be restricted to `AlertDialo
   </AlertDialogDescription>
 
   <div>
-    <button onClick={this.destroyStuff}>
+    <button onClick={destroyStuff}>
       A Destructive Action
     </button>{" "}
     <button ref={leastDestructiveRef}>
@@ -373,50 +371,53 @@ Low-level component if you need more control over the styles or rendering of the
 
 Note: You must render an `AlertDialogContent` inside.
 
-```jsx
-;() => {
-  class App extends React.Component {
-    constructor() {
-      super()
-      // you'll pass this ref to both AlertDialog and your button
-      this.cancelRef = React.createRef()
-      this.state = { confirm: false }
-      this.open = () => this.setState({ confirm: true })
-      this.close = () => this.setState({ confirm: false })
-    }
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
 
-    render() {
-      return (
-        <div>
-          <button onClick={this.open}>Delete something</button>
+  // we'll pass this ref to both AlertDialog and our button
+  const cancelRef = React.useRef();
 
-          {this.state.confirm && (
-            <AlertDialogOverlay
-              style={{ background: "hsla(0, 50%, 50%, 0.85)" }}
-              leastDestructiveRef={this.cancelRef}
-            >
-              <AlertDialogContent style={{ background: "#f0f0f0" }}>
-                <AlertDialogLabel>Please Confirm!</AlertDialogLabel>
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
 
-                <AlertDialogDescription>
-                  Are you sure you want delete stuff, it will be permanent.
-                </AlertDialogDescription>
+  return (
+    <div>
+      <button onClick={open}>
+        Delete something
+      </button>
 
-                <div className="alert-buttons">
-                  <button onClick={this.close}>Yes, delete</button>{" "}
-                  <button ref={this.cancelRef} onClick={this.close}>
-                    Nevermind
-                  </button>
-                </div>
-              </AlertDialogContent>
-            </AlertDialogOverlay>
-          )}
-        </div>
-      )
-    }
-  }
+      {showDialog && (
+        <AlertDialogOverlay
+          style={{ background: "hsla(0, 50%, 50%, 0.85)" }}
+          leastDestructiveRef={cancelRef}
+        >
+          <AlertDialogContent style={{ background: '#f0f0f0' }}>
+            <AlertDialogLabel>
+              Please Confirm!
+            </AlertDialogLabel>
 
-  return <App />
+            <AlertDialogDescription>
+              Are you sure you want delete stuff,
+              it will be permanent.
+            </AlertDialogDescription>
+
+            <div className="alert-buttons">
+              <button onClick={close}>
+                Yes, delete
+              </button>{" "}
+              <button
+                ref={cancelRef}
+                onClick={close}
+              >
+                Nevermind
+              </button>
+            </div>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      )}
+    </div>
+  );
 }
 ```
 

--- a/www/src/pages/alert.mdx
+++ b/www/src/pages/alert.mdx
@@ -19,38 +19,33 @@ Screenreader friendly alert messages. In many apps developers add "alert" messag
 
 The Alert component will announce to assistive technologies whatever you render to the screen. If you don't have a screenreader on you won't notice a difference between rendering `<Alert>` vs. a `<div>`.
 
-```jsx
-<Component initialState={{ messages: [] }}>
-  {({ setState, state }) => (
+```.jsx
+function Example(props) {
+  const [messages, setMessages] = React.useState([]);
+  return (
     <div>
       <button
         onClick={() => {
-          setState(
-            state => ({
-              messages: state.messages.concat([
-                `Message #${state.messages.length + 1}`,
-              ]),
-            }),
-            () => {
-              setTimeout(() => {
-                setState(state => ({
-                  messages: state.messages.slice(1),
-                }))
-              }, 5000)
-            }
-          )
+          setMessages(
+            prevMessages => prevMessages.concat([
+                `Message #${prevMessages.length + 1}`
+            ])
+          );
+          setTimeout(() => {
+            setMessages(prevMessages => prevMessages.slice(1));
+          }, 5000);
         }}
       >
         Add a message
       </button>
       <div>
-        {state.messages.map((message, index) => (
+        {messages.map((message, index) => (
           <Alert key={index}>{message}</Alert>
         ))}
       </div>
     </div>
-  )}
-</Component>
+  )
+}
 ```
 
 ## Installation

--- a/www/src/pages/combobox.mdx
+++ b/www/src/pages/combobox.mdx
@@ -83,12 +83,12 @@ This demo searches a client-side list of all US Cities. Combobox does not implem
 
 There is nothing special about managing state for a combobox, it's like managing state for any other list in your app. As the input changes, you figure out what state you need, then render as many ComboboxOption elements as you want.
 
-```jsx
-;(() => {
-  function Demo() {
-    const [term, setTerm] = useState("")
-    const results = useCityMatch(term)
-    const handleChange = event => setTerm(event.target.value)
+```.jsx
+(() => {
+  function Example() {
+    const [term, setTerm] = useState("");
+    const results = useCityMatch(term);
+    const handleChange = event => setTerm(event.target.value);
 
     return (
       <div>
@@ -129,19 +129,19 @@ There is nothing special about managing state for a combobox, it's like managing
     )
   }
 
-  return <Demo />
-})()
+  return <Example />;
+})();
 ```
 
 ### Server Side Search
 
 This is the same demo as above, except this time we're going to a server to get the match. This is recommended as the previous example had to download 350kb of city text! Again, there is nothing special about a ComboboxList as any other list in React. As the input changes, fetch data, set state, render options.
 
-```jsx
-;(() => {
-  function ServerCitySearch() {
-    const [searchTerm, setSearchTerm] = useState("")
-    const cities = useCitySearch(searchTerm)
+```.jsx
+(() => {
+  function Example() {
+    const [searchTerm, setSearchTerm] = useState("");
+    const cities = useCitySearch(searchTerm);
     const handleSearchTermChange = event => {
       setSearchTerm(event.target.value)
     }
@@ -196,8 +196,8 @@ This is the same demo as above, except this time we're going to a server to get 
       })
   }
 
-  return <ServerCitySearch />
-})()
+  return <Example />
+})();
 ```
 
 ### Lots of arbitrary elements
@@ -206,12 +206,12 @@ Sometimes your list is a bit more complicated, like categories of results, and l
 
 You can even have other interactive elements inside the popover, it won't close when the user interacts with them.
 
-```jsx
-;(() => {
-  function Demo() {
-    const [term, setTerm] = useState("")
-    const results = useCityMatch(term)
-    const handleChange = event => setTerm(event.target.value)
+```.jsx
+(() => {
+  function Example() {
+    const [term, setTerm] = useState("");
+    const results = useCityMatch(term);
+    const handleChange = event => setTerm(event.target.value);
 
     return (
       <div>
@@ -283,20 +283,20 @@ You can even have other interactive elements inside the popover, it won't close 
     padding: 5,
   }
 
-  return <Demo />
-})()
+  return <Example />;
+})();
 ```
 
 ### Custom styling
 
 This demo shows how you can control a lot about the styling. It uses `portal={false}` on the ComboboxPopover which allows us to create a continuous outline around the entire thing.
 
-```jsx
-;(() => {
-  function PinkDemo() {
-    let [term, setTerm] = useState("")
-    let results = useCityMatch(term)
-    const handleChange = event => setTerm(event.target.value)
+```.jsx
+(() => {
+  function Example() {
+    let [term, setTerm] = useState("");
+    let results = useCityMatch(term);
+    const handleChange = event => setTerm(event.target.value);
 
     return (
       <Combobox className="pink">
@@ -344,8 +344,8 @@ This demo shows how you can control a lot about the styling. It uses `portal={fa
     )
   }
 
-  return <PinkDemo />
-})()
+  return <Example />;
+})();
 ```
 
 ## CSS Selectors

--- a/www/src/pages/dialog.mdx
+++ b/www/src/pages/dialog.mdx
@@ -21,21 +21,25 @@ import Helmet from "react-helmet"
 
 An accessible dialog or "modal" window.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Open Dialog
       </button>
 
       <Dialog
-        isOpen={state.showDialog}
-        onDismiss={() => setState({ showDialog: false })}
+        isOpen={showDialog}
+        onDismiss={close}
       >
         <button
           className="close-button"
-          onClick={() => setState({ showDialog: false })}
+          onClick={close}
         >
           <VisuallyHidden>Close</VisuallyHidden>
           <span aria-hidden>×</span>
@@ -43,8 +47,8 @@ An accessible dialog or "modal" window.
         <p>Hello there. I am a dialog</p>
       </Dialog>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ## Installation
@@ -86,25 +90,31 @@ _Type_: `spread`
 
 Any props not listed above will be spread onto the underlying `DialogContent` element, which in turn is spread onto the underlying `div[data-reach-dialog-content]`.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
       <Dialog
         style={{ color: "red" }}
-        isOpen={state.showDialog}
-        onDismiss={() => setState({ showDialog: false })}
+        isOpen={showDialog}
+        onDismiss={close}
       >
         <p>My text is red because the style prop got applied to the div</p>
-        <button onClick={() => setState({ showDialog: false })}>Okay</button>
+        <button onClick={close}>
+          Okay
+        </button>
       </Dialog>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ### Dialog isOpen
@@ -127,26 +137,32 @@ If you'd rather not have the dialog always rendered, you can put a guard in fron
 
 Note, however, that the dialog will not render to the DOM when `isOpen={false}`, but you may want to save on the number of elements created in your render function. You should probably do this when your dialog contains a lot of elements.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
-      {state.showDialog && (
-        <Dialog onDismiss={() => setState({ showDialog: false })}>
+      {showDialog && (
+        <Dialog onDismiss={close}>
           <p>
             I don’t use <code>isOpen</code>, I just render when I should and not
             when I shouldn’t.
           </p>
-          <button onClick={() => setState({ showDialog: false })}>Okay</button>
+          <button onClick={close}>
+            Okay
+          </button>
         </Dialog>
       )}
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ### Dialog onDismiss
@@ -157,55 +173,75 @@ This function is called whenever the user hits "Escape" or clicks outside the di
 
 The only time you shouldn't close the dialog on dismiss is when the dialog requires a choice and none of them are "cancel". For example, perhaps two records need to be merged and the user needs to pick the surviving record. Neither choice is less destructive than the other, in these cases you may want to alert the user they need to a make a choice on dismiss instead of closing the dialog.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
       <Dialog
-        isOpen={state.showDialog}
-        onDismiss={() => setState({ showDialog: false })}
+        isOpen={showDialog}
+        onDismiss={close}
       >
         <p>
           It is your job to close this with state when the user clicks outside
           or presses escape.
         </p>
-        <button onClick={() => setState({ showDialog: false })}>Okay</button>
+        <button onClick={close}>
+          Okay
+        </button>
       </Dialog>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
-```jsx
-<Component initialState={{ showDialog: false, warn: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const [showWarning, setShowWarning] = React.useState(false);
+  const open = () => {
+    setShowDialog(true);
+    setShowWarning(false);
+  };
+  const close = () => setShowDialog(false);
+  const dismiss = () => setShowWarning(true);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
       <Dialog
-        isOpen={state.showDialog}
-        onDismiss={() => setState({ warn: true })}
+        isOpen={showDialog}
+        onDismiss={dismiss}
       >
-        {state.warn && (
-          <p style={{ color: "red" }}>You must make a choice, sorry :(</p>
+        {showWarning && (
+          <p style={{ color: 'red' }}>
+            You must make a choice, sorry :(
+          </p>
         )}
-        <p>Which router should survive the merge?</p>
-        <button onClick={() => setState({ showDialog: false })}>
+        <p>
+          Which router should survive the merge?
+        </p>
+        <button onClick={close}>
           React Router
-        </button>{" "}
-        <button onClick={() => setState({ showDialog: false })}>
+        </button>
+        {" "}
+        <button onClick={close}>
           @reach/router
         </button>
       </Dialog>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ### Dialog children
@@ -226,34 +262,33 @@ Low-level component if you need more control over the styles or rendering of the
 
 Note: You must render a `DialogContent` inside.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
       <DialogOverlay
         style={{ background: "hsla(0, 100%, 100%, 0.9)" }}
-        isOpen={state.showDialog}
-        onDismiss={() => setState({ showDialog: false })}
+        isOpen={showDialog}
+        onDismiss={close}
       >
-        <DialogContent
-          style={{ boxShadow: "0px 10px 50px hsla(0, 0%, 0%, 0.33)" }}
-        >
-          <p>
-            The overlay styles are a white fade instead of the default black
-            fade.
-          </p>
-          <button onClick={() => setState({ showDialog: false })}>
+        <DialogContent style={{ boxShadow: '0px 10px 50px hsla(0, 0%, 0%, 0.33)' }}>
+          <p>The overlay styles are a white fade instead of the default black fade.</p>
+          <button onClick={close}>
             Very nice.
           </button>
         </DialogContent>
       </DialogOverlay>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ## DialogOverlay CSS Selectors
@@ -308,44 +343,39 @@ _Type_: `ref`
 
 By default the first focusable element will receive focus when the dialog opens but you can provide a ref to focus instead.
 
-```jsx
-;() => {
-  class App extends React.Component {
-    constructor() {
-      super()
-      this.buttonRef = React.createRef()
-      this.state = { showDialog: false }
-      this.open = () => this.setState({ showDialog: true })
-      this.close = () => this.setState({ showDialog: false })
-    }
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const buttonRef = React.useRef();
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
 
-    render() {
-      return (
-        <div>
-          <button onClick={this.open}>Show Dialog</button>
+  return (
+    <div>
+      <button onClick={open}>Show Dialog</button>
 
-          {this.state.showDialog && (
-            <DialogOverlay
-              initialFocusRef={this.buttonRef}
-              onDismiss={this.close}
+      {showDialog && (
+        <DialogOverlay
+          initialFocusRef={buttonRef}
+          onDismiss={close}
+        >
+          <DialogContent>
+            <p>
+              Pass the button ref to DialogOverlay and
+              the button.
+            </p>
+            <button onClick={close}>Not me</button>{" "}
+            <button
+              ref={buttonRef}
+              onClick={close}
             >
-              <DialogContent>
-                <p>Pass the button ref to DialogOverlay and the button.</p>
-                <button onClick={this.close}>Not me</button> <button
-                  ref={this.buttonRef}
-                  onClick={this.close}
-                >
-                  Got me!
-                </button>
-              </DialogContent>
-            </DialogOverlay>
-          )}
-        </div>
-      )
-    }
-  }
-
-  return <App />
+              Got me!
+            </button>
+          </DialogContent>
+        </DialogOverlay>
+      )}
+    </div>
+  );
 }
 ```
 
@@ -369,17 +399,22 @@ Note: Must be a child of `DialogOverlay`.
 
 Note: You only need to use this when you are also styling `DialogOverlay`, otherwise you can use the high-level `Dialog` component and pass the props to it. Any props passed to `Dialog` component (besides `isOpen` and `onDismiss`) will be spread onto `DialogContent`.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const buttonRef = React.useRef();
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
       <DialogOverlay
-        isOpen={state.showDialog}
-        onDismiss={() => setState({ showDialog: false })}
+        isOpen={showDialog}
+        onDismiss={close}
       >
         <DialogContent
           style={{
@@ -388,18 +423,15 @@ Note: You only need to use this when you are also styling `DialogOverlay`, other
           }}
         >
           <p>I have a nice border now.</p>
-          <p>
-            Note that we could have used the simpler <code>Dialog</code>{" "}
-            instead.
-          </p>
-          <button onClick={() => setState({ showDialog: false })}>
+          <p>Note that we could have used the simpler <code>Dialog</code> instead.</p>
+          <button onClick={close}>
             Got it.
           </button>
         </DialogContent>
       </DialogOverlay>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ## DialogContent CSS Selectors
@@ -449,11 +481,16 @@ Accepts any renderable content.
 
 If you'd like to animate the content, give [React Spring](https://github.com/drcmda/react-spring) a shot.
 
-```jsx
-<Component initialState={{ showDialog: false }}>
-  {({ state, setState }) => (
+```.jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const buttonRef = React.useRef();
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
     <div>
-      <button onClick={() => setState({ showDialog: true })}>
+      <button onClick={open}>
         Show Dialog
       </button>
 
@@ -462,11 +499,11 @@ If you'd like to animate the content, give [React Spring](https://github.com/drc
         enter={{ opacity: 1, y: 0 }}
         leave={{ opacity: 0, y: 10 }}
       >
-        {state.showDialog &&
+        {showDialog &&
           (styles => (
             <DialogOverlay
               style={{ opacity: styles.opacity }}
-              onDismiss={() => setState({ showDialog: false })}
+              onDismiss={close}
             >
               <DialogContent
                 style={{
@@ -475,7 +512,7 @@ If you'd like to animate the content, give [React Spring](https://github.com/drc
                   borderRadius: 10,
                 }}
               >
-                <button onClick={() => setState({ showDialog: false })}>
+                <button onClick={close}>
                   Close Dialog
                 </button>
                 <p>React Spring makes it too easy!</p>
@@ -485,8 +522,8 @@ If you'd like to animate the content, give [React Spring](https://github.com/drc
           ))}
       </Transition>
     </div>
-  )}
-</Component>
+  );
+}
 ```
 
 ## Accessibility

--- a/www/src/pages/funding.mdx
+++ b/www/src/pages/funding.mdx
@@ -5,8 +5,9 @@ import Helmet from "react-helmet"
   meta={[
     {
       name: "description",
-      content: "Development is funded by Ryan Florence's online courses and workshops at https://reach.tech"
-    }
+      content:
+        "Development is funded by Ryan Florence's online courses and workshops at https://reach.tech",
+    },
   ]}
 />
 

--- a/www/src/pages/index.mdx
+++ b/www/src/pages/index.mdx
@@ -7,7 +7,6 @@ You can get involved by:
 - Joining the [Spectrum Community](https://spectrum.chat/reach)
 - Following on [GitHub](https://github.com/reach/reach-ui)
 
-
 Each component is tested with Safari + Voiceover, Firefox + NVDA, and Edge + JAWS. As the project matures we’ll get it audited by Web AIM to ensure that if you pick Reach UI, your app has a solid, accessible foundation.
 
 Development of Reach UI is funded by [online courses](https://reach.tech/courses) and [workshops](https://reach.tech/workshops) provided by [Ryan Florence](https://twitter.com/ryanflorence).
@@ -17,4 +16,3 @@ Development of Reach UI is funded by [online courses](https://reach.tech/courses
 1. Read the [Styling Guide](/styling)
 2. Read the docs for a component, how about the [MenuButton](/menu-button)?
 3. Many of the examples in the docs are interactive, so go ahead and tinker!
-

--- a/www/src/pages/menu-button.mdx
+++ b/www/src/pages/menu-button.mdx
@@ -342,17 +342,16 @@ All props are spread to the underlying element.
 
 In this example the `onFocus` prop is passed down to the element.
 
-```jsx
-<Component initialState={{ focusCount: 0 }}>
-  {({ setState, state: { focusCount } }) => (
+```.jsx
+function Example(props) {
+  const [focusCount, setFocusCount] = React.useState(0);
+  return (
     <Menu>
       <MenuButton>Actions</MenuButton>
       <MenuList>
         <MenuItem
           onFocus={() => {
-            setState(state => ({
-              focusCount: state.focusCount + 1,
-            }))
+            setFocusCount(prevFocusCount => prevFocusCount + 1);
           }}
           onSelect={() => {}}
         >
@@ -362,8 +361,8 @@ In this example the `onFocus` prop is passed down to the element.
         <MenuItem onSelect={() => {}}>Send a Message</MenuItem>
       </MenuList>
     </Menu>
-  )}
-</Component>
+  );
+}
 ```
 
 ### MenuItem children
@@ -400,15 +399,15 @@ Handles linking to a different page in the menu. By default it renders `<a>`, bu
 Must be a direct child of a `<MenuList>`.
 
 ```jsx
-improt { Link } from "@reach/router"
-
-<MenuList>
-  <MenuLink as={Link} to="somewhere/else">Somewhere w/ Reach Router</MenuLink>
+import { Link } from "@reach/router"
+;<MenuList>
+  <MenuLink as={Link} to="somewhere/else">
+    Somewhere w/ Reach Router
+  </MenuLink>
   <MenuLink href="https://reactjs.org">Official React Site</MenuLink>
-  <MenuLink
-    as={GatsbyLink}
-    to="/somewhere/with/gatsby"
-  >Some Gatsby Page</MenuLink>
+  <MenuLink as={GatsbyLink} to="/somewhere/with/gatsby">
+    Some Gatsby Page
+  </MenuLink>
 </MenuList>
 ```
 
@@ -509,62 +508,56 @@ If one of your menu items causes the `<Menu>` itself to unmount, it is your job 
 
 Note the callbacks given to `setState` in the following demo app where focus is managed between screens. If you don't do this you'll drop keyboard and screenreader users off at the top of the document. It'll then be hard for them to know what changed and how to find it. Moving focus helps them stay where you want them the very same way visual design does.
 
-```jsx
-;(() => {
-  class App extends React.Component {
-    constructor() {
-      super()
-      this.focusRefs = {
-        screen1: React.createRef(),
-        screenTwoButton: React.createRef(),
-      }
-
-      this.state = {
-        screen: 1,
-      }
+```.jsx
+function Example(props) {
+  const screen1FocusRef = React.useRef();
+  const screen2ButtonFocusRef = React.useRef();
+  React.useEffect(() => {
+    if (screen === 1) {
+      screen1FocusRef.current.focus();
     }
-
-    render() {
-      return this.state.screen === 1 ? (
-        <div ref={this.focusRefs.screen1} tabIndex="-1">
-          <h4>Screen One</h4>
-          <Menu>
-            <MenuButton>Actions</MenuButton>
-            <MenuList>
-              <MenuItem
-                onSelect={() => {
-                  this.setState({ screen: 2 }, () => {
-                    this.focusRefs.screenTwoButton.current.focus()
-                  })
-                }}
-              >
-                Go to screen 2
-              </MenuItem>
-              <MenuItem onSelect={() => {}}>Do nothing</MenuItem>
-            </MenuList>
-          </Menu>
-          <Menu />
-        </div>
-      ) : this.state.screen === 2 ? (
-        <div>
-          <h4>Screen 2</h4>
-          <button
-            ref={this.focusRefs.screenTwoButton}
-            onClick={() => {
-              this.setState({ screen: 1 }, () =>
-                this.focusRefs.screen1.current.focus()
-              )
-            }}
-          >
-            Back to screen 1
-          </button>
-        </div>
-      ) : null
+    if (screen === 2) {
+      screen2ButtonFocusRef.current.focus();
     }
+  }, [screen]);
+
+  const [screen, setScreen] = React.useState(1);
+  if (screen === 1) {
+    return (
+      <div ref={screen1FocusRef} tabIndex="-1">
+        <h4>Screen One</h4>
+        <Menu>
+          <MenuButton>Actions</MenuButton>
+          <MenuList>
+            <MenuItem
+              onSelect={() => setScreen(2)}
+            >
+              Go to screen 2
+            </MenuItem>
+            <MenuItem onSelect={() => {}}>
+              Do nothing
+            </MenuItem>
+          </MenuList>
+        </Menu>
+        <Menu />
+      </div>
+    );
   }
-
-  return <App />
-})()
+  if (screen === 2) {
+    return (
+      <div>
+        <h4>Screen 2</h4>
+        <button
+          ref={screen2ButtonFocusRef}
+          onClick={() => setScreen(1)}
+        >
+          Back to screen 1
+        </button>
+      </div>
+    )
+  }
+  return null;
+}
 ```
 
 ## Icons

--- a/www/src/pages/rect.mdx
+++ b/www/src/pages/rect.mdx
@@ -41,37 +41,33 @@ Hook that observes and returns the measurements (ClientRect) of a DOM element. P
 
 If `observe` is false, the element's rect will no longer be observed, pass it `true` again and it will. This is mostly used for things like popovers and animations, so you can usually observe when you need to, and stop observing when you don't.
 
-```jsx
-;(() => {
-  function Example() {
-    // your own ref
-    const ref = useRef()
+```.jsx
+function Example() {
+  // your own ref
+  const ref = useRef();
 
-    // pass it in to be observered
-    const rect = useRect(ref)
+  // pass it in to be observered
+  const rect = useRect(ref);
 
-    return (
-      <div>
-        <pre>{JSON.stringify(rect, null, 2)}</pre>
-        <div
-          // and then place the ref
-          ref={ref}
-          contentEditable
-          style={{
-            display: "inline-block",
-            padding: 10,
-            border: "solid 1px",
-          }}
-          dangerouslySetInnerHTML={{
-            __html: "Edit this to change the size!",
-          }}
-        />
-      </div>
-    )
-  }
-
-  return <Example />
-})()
+  return (
+    <div>
+      <pre>{JSON.stringify(rect, null, 2)}</pre>
+      <div
+        // and then place the ref
+        ref={ref}
+        contentEditable
+        style={{
+          display: "inline-block",
+          padding: 10,
+          border: "solid 1px"
+        }}
+        dangerouslySetInnerHTML={{
+          __html: "Edit this to change the size!"
+        }}
+      />
+    </div>
+  );
+}
 ```
 
 # Rect

--- a/www/src/pages/skip-nav.mdx
+++ b/www/src/pages/skip-nav.mdx
@@ -3,7 +3,10 @@ import Helmet from "react-helmet"
 <Helmet
   title="Reach UI - SkipNav"
   meta={[
-    { name: 'description', content: "Skip navigation link for screenreader and keyboard users." }
+    {
+      name: "description",
+      content: "Skip navigation link for screenreader and keyboard users.",
+    },
   ]}
 />
 
@@ -19,18 +22,19 @@ If the user does not navigate with the keyboard, they won't see the link.
 For a demo, click some empty space on this page to move focus to the document body, then hit the "tab" key You'll see the link pop up. Hit enter, then tab again. Rather than cycling through the navigation, you are tabbing through the main content of the page.
 
 ```jsx
-ReactDOM.render((
+ReactDOM.render(
   <React.Fragment>
     {/* put the link at the top of your app */}
-    <SkipNavLink/>
+    <SkipNavLink />
     <div>
-      <YourNav/>
+      <YourNav />
       {/* and the content next to your main content */}
-      <SkipNavContent/>
-      <YourMainContent/>
+      <SkipNavContent />
+      <YourMainContent />
     </div>
-  </React.Fragment>
-), rootNode)
+  </React.Fragment>,
+  rootNode
+)
 ```
 
 ## Installation
@@ -42,7 +46,7 @@ yarn add @reach/skip-nav
 And then import it:
 
 ```js
-import { SkipNavLink, SkipNavContent } from '@reach/skip-nav'
+import { SkipNavLink, SkipNavContent } from "@reach/skip-nav"
 ```
 
 # SkipNavLink
@@ -52,26 +56,28 @@ Renders a link that remains hidden until focused to skip to the main content.
 ## SkipNavLink CSS Selectors
 
 ```css
-[data-reach-skip-link] {  }
-[data-reach-skip-link]:focus { }
+[data-reach-skip-link] {
+}
+[data-reach-skip-link]:focus {
+}
 ```
 
 ## SkipNavLink Props
 
-| Prop                   | Type   |
-| -----------------------| ------ |
-| [element props](#skipnavlink-element-props)  | spread |
-| [children](#skipnavlink-children)  | node |
+| Prop                                        | Type   |
+| ------------------------------------------- | ------ |
+| [element props](#skipnavlink-element-props) | spread |
+| [children](#skipnavlink-children)           | node   |
 
 ### SkipNavLink element props
 
-*Type*: `spread`
+_Type_: `spread`
 
 Element props are spread to the underlying link.
 
 ### SkipNavLink children
 
-*Type*: `node` default: `"Skip to content"`
+_Type_: `node` default: `"Skip to content"`
 
 Allows you to change the text for your preferred phrase or localization.
 
@@ -85,13 +91,13 @@ Renders a div as the target for the link.
 
 ## SkipNavLink Props
 
-| Prop                   | Type   |
-| -----------------------| ------ |
-| [children](#skipnavcontent-children)  | node |
+| Prop                                 | Type |
+| ------------------------------------ | ---- |
+| [children](#skipnavcontent-children) | node |
 
 ### SkipNavLink children
 
-*Type*: `node`
+_Type_: `node`
 
 You can place the `SkipNavContent` element as a sibling to your main content or as a wrapper:
 
@@ -107,4 +113,3 @@ You can place the `SkipNavContent` element as a sibling to your main content or 
 ```
 
 Keep in mind it renders a `div`, so it may mess with your CSS depending on where it’s placed.
-

--- a/www/src/pages/styling.mdx
+++ b/www/src/pages/styling.mdx
@@ -5,17 +5,18 @@ import Helmet from "react-helmet"
   meta={[
     {
       name: "description",
-      content: "Styling a Reach component feels similar to styling any native element. There are no themes and you don't have to prescribe to any specific approach to styling. There are some basic styles to make the components usable off-the-shelf, but you can override and add to them with stylesheets, styled components, emotion, glamor, whatever you want."
-    }
+      content:
+        "Styling a Reach component feels similar to styling any native element. There are no themes and you don't have to prescribe to any specific approach to styling. There are some basic styles to make the components usable off-the-shelf, but you can override and add to them with stylesheets, styled components, emotion, glamor, whatever you want.",
+    },
   ]}
 />
 
 # Styling
 
-[Including Base Styles](#including-base-styles) - 
+[Including Base Styles](#including-base-styles) -
 [Overriding and Adding New Styles](#overriding--adding-new-styles)
 
-Styling a Reach component feels similar to styling any native element. There are no themes and you don't have to prescribe to any specific approach to styling. There are some basic styles to make the components usable off-the-shelf, but you can override and add to them with stylesheets, styled components, emotion, glamor, whatever you want.  
+Styling a Reach component feels similar to styling any native element. There are no themes and you don't have to prescribe to any specific approach to styling. There are some basic styles to make the components usable off-the-shelf, but you can override and add to them with stylesheets, styled components, emotion, glamor, whatever you want.
 
 # Including Base Styles
 
@@ -45,12 +46,7 @@ If you are using a module bundler like webpack or parcel, you can import them wh
 
 ```jsx
 // import the components
-import {
-  Menu,
-  MenuButton,
-  MenuList,
-  MenuItem
-} from "@reach/menu-button"
+import { Menu, MenuButton, MenuList, MenuItem } from "@reach/menu-button"
 
 // and the styles
 import "@reach/menu-button/styles.css"
@@ -66,7 +62,7 @@ If you’re not using a bundler you can find the styles at:
 
 `your-app/node_modules/@reach/<package-name>/styles.css`
 
-Include those files however you include the rest of your stylesheets.  Alternatively, you can use a CDN like Unpkg, but this is not recommended for production apps.
+Include those files however you include the rest of your stylesheets. Alternatively, you can use a CDN like Unpkg, but this is not recommended for production apps.
 
 ```html
 <link
@@ -102,7 +98,6 @@ let YourMenuList = styled(MenuList)`
 <MenuList css={absolutely}/>
 ```
 
-
 ## CSS Selectors
 
 Because Reach UI uses regular stylesheets for its own styles you can override them like any other element. All styles use the lowest possible "specificity score", so as long as you include the component styles before your own app styles you should not run into any specificity problems.
@@ -128,6 +123,3 @@ There are certain states an element can go into like "selected". To target these
   background: red;
 }
 ```
-
-
-

--- a/www/src/pages/tabs.mdx
+++ b/www/src/pages/tabs.mdx
@@ -121,37 +121,32 @@ _Type_: `function`
 
 Calls back with the tab index whenever the user changes tabs, allowing your app to synchronize with it.
 
-```jsx
-;(() => {
-  const colors = ["firebrick", "goldenrod", "dodgerblue"]
-
-  function Example() {
-    const [tabIndex, setTabIndex] = useState(0)
-    const backgroundColor = colors[tabIndex]
-    return (
-      <Tabs
-        onChange={index => setTabIndex(index)}
-        style={{
-          color: "white",
-          background: backgroundColor,
-        }}
-      >
-        <TabList>
-          <Tab>Red</Tab>
-          <Tab>Yellow</Tab>
-          <Tab>Blue</Tab>
-        </TabList>
-        <TabPanels style={{ padding: 20 }}>
-          <TabPanel>The Primary Colors</TabPanel>
-          <TabPanel>Are 1, 2, 3</TabPanel>
-          <TabPanel>Red, yellow and blue.</TabPanel>
-        </TabPanels>
-      </Tabs>
-    )
-  }
-
-  return <Example />
-})()
+```.jsx
+function Example() {
+  const colors = ["firebrick", "goldenrod", "dodgerblue"];
+  const [tabIndex, setTabIndex] = useState(0);
+  const backgroundColor = colors[tabIndex];
+  return (
+    <Tabs
+      onChange={index => setTabIndex(index)}
+      style={{
+        color: "white",
+        background: backgroundColor
+      }}
+    >
+      <TabList>
+        <Tab>Red</Tab>
+        <Tab>Yellow</Tab>
+        <Tab>Blue</Tab>
+      </TabList>
+      <TabPanels style={{ padding: 20 }}>
+        <TabPanel>The Primary Colors</TabPanel>
+        <TabPanel>Are 1, 2, 3</TabPanel>
+        <TabPanel>Red, yellow and blue.</TabPanel>
+      </TabPanels>
+    </Tabs>
+  );
+}
 ```
 
 ### Tabs defaultIndex
@@ -164,10 +159,13 @@ Starts the tabs at a specific index.
 <Tabs defaultIndex={1}>
   <TabPanels>
     <TabPanel>
-      <img src="https://placekitten.com/400/200" />
+      <img src="https://placekitten.com/400/200" alt="A picture of a cat" />
     </TabPanel>
     <TabPanel>
-      <img src="https://placecage.com/400/200" />
+      <img
+        src="https://www.placecage.com/400/200"
+        alt="A picture of Nicolas Cage"
+      />
     </TabPanel>
   </TabPanels>
   <TabList>
@@ -183,53 +181,52 @@ _Type_: `number`
 
 Like form inputs, a tab's state can be controlled by the owner. Make sure to include an `onChange` as well, or else the tabs will not be interactive.
 
-```jsx
-;(() => {
-  function ControlledExample() {
-    const [tabIndex, setTabIndex] = useState(0)
+```.jsx
+function Example() {
+  const [tabIndex, setTabIndex] = useState(0);
 
-    const handleSliderChange = event => {
-      setTabIndex(parseInt(event.target.value, 10))
-    }
-
-    const handleTabsChange = index => {
-      setTabIndex(index)
-    }
-
-    return (
-      <div>
-        <input
-          type="range"
-          min="0"
-          max="2"
-          value={tabIndex}
-          onChange={handleSliderChange}
-        />
-
-        <Tabs index={tabIndex} onChange={handleTabsChange}>
-          <TabList>
-            <Tab>One</Tab>
-            <Tab>Two</Tab>
-            <Tab>Three</Tab>
-          </TabList>
-          <TabPanels>
-            <TabPanel>
-              <p>Click the tabs or pull the slider around</p>
-            </TabPanel>
-            <TabPanel>
-              <p>Yeah yeah. What's up?</p>
-            </TabPanel>
-            <TabPanel>
-              <p>Oh, hello there.</p>
-            </TabPanel>
-          </TabPanels>
-        </Tabs>
-      </div>
-    )
+  const handleSliderChange = event => {
+    setTabIndex(parseInt(event.target.value, 10));
   }
 
-  return <ControlledExample />
-})()
+  const handleTabsChange = index => {
+    setTabIndex(index)
+  }
+
+  return (
+    <div>
+      <input
+        type="range"
+        min="0"
+        max="2"
+        value={tabIndex}
+        onChange={handleSliderChange}
+      />
+
+      <Tabs
+        index={tabIndex}
+        onChange={handleTabsChange}
+      >
+        <TabList>
+          <Tab>One</Tab>
+          <Tab>Two</Tab>
+          <Tab>Three</Tab>
+        </TabList>
+        <TabPanels>
+          <TabPanel>
+            <p>Click the tabs or pull the slider around</p>
+          </TabPanel>
+          <TabPanel>
+            <p>Yeah yeah. What's up?</p>
+          </TabPanel>
+          <TabPanel>
+            <p>Oh, hello there.</p>
+          </TabPanel>
+        </TabPanels>
+      </Tabs>
+    </div>
+  );
+}
 ```
 
 ### Tabs as


### PR DESCRIPTION
This pull request goes through all the different docs, and does the following:

- removes usage of component-component in favor of function components with hooks
- refactors class component examples to use function components and hooks
- standardize all example component names to `Example`
- Fix a few typos, broken links and what not

Fixes #269 