### PR TITLE
VisuallyHidden: Use a named function so it has a display name 

### DIFF
--- a/packages/visually-hidden/src/index.js
+++ b/packages/visually-hidden/src/index.js
@@ -11,6 +11,8 @@ let style = {
   position: "absolute"
 };
 
-export default props => {
+function VisuallyHidden(props) {
   return <div style={style} {...props} />;
-};
+}
+
+export default VisuallyHidden;


### PR DESCRIPTION
At the moment `VisuallyHidden` shows up in the React dev tools as `Anonymous` and in snapshot tests as `Component`, but by making it a named function it'll just say `VisuallyHidden`. 👍 