### PR TITLE
Set author fields to uniform value

### DIFF
--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -15,7 +15,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/auto-id/package.json
+++ b/packages/auto-id/package.json
@@ -12,7 +12,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -18,7 +18,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -15,7 +15,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/rect/package.json
+++ b/packages/rect/package.json
@@ -17,7 +17,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/skip-nav/package.json
+++ b/packages/skip-nav/package.json
@@ -12,7 +12,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -18,7 +18,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "react-spring": "^8.0.19"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -12,7 +12,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "Ryan Florence",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",

--- a/packages/window-size/package.json
+++ b/packages/window-size/package.json
@@ -15,7 +15,7 @@
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },
-  "author": "",
+  "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "files": [
     "es",


### PR DESCRIPTION
Our site likes to [credit authors whose works are used](https://observablehq.com/open-source), and unfortunately reach/portal and reach/rect, which we use, have blank author fields. This PR sets all author fields for all reach-ui packages to `"Ryan Florence <@ryanflorence>"`, which was the value for the ones that were filled out before.