### PR TITLE
fixing null children issue

### DIFF
--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -48,7 +48,7 @@ export const Tabs = forwardRef(function Tabs(
 
   const clones = React.Children.map(children, child => {
     // ignore random <div/>s etc.
-    if (typeof child.type === "string") return child;
+    if (!child || typeof child.type === "string") return child;
     return cloneElement(child, {
       selectedIndex: isControlled ? controlledIndex : selectedIndex,
       _id,


### PR DESCRIPTION
I am currently using the tabs component and noticed that if I conditionally render a child inside <Tabs> the following error occurs when the conditional returns false:

`Cannot read property 'type' of null`

This only happens when I conditionally render using the '&&' operator.

example:
```
<Tabs> 
{someCondition && <div />}
<Tabs>
```