### PR TITLE
docs(tabs): fix typo in tab isselected section

### DIFF
--- a/www/src/pages/tabs.mdx
+++ b/www/src/pages/tabs.mdx
@@ -483,7 +483,7 @@ Please see the ["as" prop documentation](/as-prop) for more information
 
 _Type_: `number` - cloned
 
-Because TabList needs to know the order of hte children, we use `cloneElement` to pass state internally. If you want to know if a tab is active, you can wrap it, and then inspect clone props passed in. Note that any props that start with `_` are not public API, so don't use them :)
+Because TabList needs to know the order of the children, we use `cloneElement` to pass state internally. If you want to know if a tab is active, you can wrap it, and then inspect clone props passed in. Note that any props that start with `_` are not public API, so don't use them :)
 
 ```.jsx
 (() => {


### PR DESCRIPTION
Fixes a typo found in the "Tab isSelected" section of the "Tabs" docs