### PR TITLE
Revert "add missing peer deps and use a more forgiving range"

### DIFF
--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -18,7 +18,6 @@
     "invariant": "^2.2.4"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -12,7 +12,6 @@
     "@reach/visually-hidden": "^0.1.4"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -19,7 +19,7 @@
     "highlight-words-core": "1.2.0"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
+    "prop-types": "^15.6.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/component-component/package.json
+++ b/packages/component-component/package.json
@@ -11,7 +11,7 @@
   "author": "Ryan Florence <@ryanflorence>",
   "license": "MIT",
   "peerDependencies": {
-    "prop-types": "^15.x",
+    "prop-types": "^15.6.2",
     "react": "^16.4.0",
     "react-dom": "^16.4.0"
   },

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -18,7 +18,6 @@
     "react-remove-scroll": "^1.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/menu-button/package.json
+++ b/packages/menu-button/package.json
@@ -19,7 +19,7 @@
     "warning": "^4.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
+    "prop-types": "^15.6.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/rect/package.json
+++ b/packages/rect/package.json
@@ -13,7 +13,7 @@
     "@reach/observe-rect": "^1.0.3"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
+    "prop-types": "^15.6.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -14,7 +14,7 @@
     "warning": "^4.0.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
+    "prop-types": "^15.7.2",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -13,10 +13,10 @@
     "@reach/portal": "^0.2.1",
     "@reach/rect": "^0.2.1",
     "@reach/utils": "^0.2.3",
-    "@reach/visually-hidden": "^0.1.4"
+    "@reach/visually-hidden": "^0.1.4",
+    "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },

--- a/packages/window-size/package.json
+++ b/packages/window-size/package.json
@@ -12,7 +12,6 @@
     "@reach/component-component": "^0.1.3"
   },
   "peerDependencies": {
-    "prop-types": "^15.x",
     "react": "^16.8.0",
     "react-dom": "^16.8.0"
   },


### PR DESCRIPTION
Reverts reach/reach-ui#254

I mistakenly merged #254. prop-types are not a peer dep. They are a regular dep that gets stripped out in production.