### PR TITLE
Fix typo in Portal docs page (WindowSize -> Portal)

### DIFF
--- a/www/src/pages/portal.mdx
+++ b/www/src/pages/portal.mdx
@@ -52,7 +52,7 @@ yarn add @reach/portal
 And then import it:
 
 ```js
-import WindowSize from "@reach/portal"
+import Portal from "@reach/portal"
 ```
 
 ## Props


### PR DESCRIPTION
This pull request fixes a typo on the Portal docs page where the documentation mentions WindowSize when importing instead of Portal (but the example earlier on the page uses `<Portal>`).

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other