### PR TITLE
useId: Refactor to prevent ID change after first render

### DIFF
--- a/packages/auto-id/examples/basic.example.js
+++ b/packages/auto-id/examples/basic.example.js
@@ -1,0 +1,20 @@
+import React from "react";
+import "@reach/dialog/styles.css";
+import { useId } from "../src/index";
+
+export let name = "Basic";
+
+export let Example = () => {
+  const divId = `div:${useId()}`;
+  const buttonId = `div:${useId()}`;
+  return (
+    <>
+      <div id={divId}>
+        This element has an ID of <strong>{divId}</strong>
+      </div>
+      <button id={buttonId} onClick={() => false}>
+        This element has an ID of <strong>{buttonId}</strong>
+      </button>
+    </>
+  );
+};

--- a/packages/auto-id/src/index.js
+++ b/packages/auto-id/src/index.js
@@ -1,15 +1,47 @@
-import { useState, useEffect } from "react";
-
-// Could use UUID but if we hit 9,007,199,254,740,991 unique components over
-// the lifetime of the app before it gets reloaded, I mean ... come on.
-// I don't even know what xillion that is.
-// /me googles
-// Oh duh, quadrillion. Nine quadrillion components. I think we're okay.
-let id = 0;
-const genId = () => ++id;
+// https://github.com/thearnica/react-uid/blob/master/src/hooks.ts
+import { createContext, useContext, useState } from "react";
 
 export const useId = () => {
-  const [id, setId] = useState(null);
-  useEffect(() => setId(genId()), []);
+  const [{ id }] = useIDState();
   return id;
 };
+
+const counter = createSource();
+const source = createContext(createSource());
+const getId = source => source.value++;
+
+function genId(context) {
+  const quartz = context || counter;
+  const id = getId(quartz);
+  const gen = item => id + quartz.id(item);
+  return { id, gen };
+}
+
+function useIDState() {
+  return useState(genId(useContext(source)));
+}
+
+function generateUID() {
+  let counter = 1;
+  const map = new WeakMap();
+  function id(item, index) {
+    if (typeof item === "number" || typeof item === "string") {
+      return index ? `idx-${index}` : `val-${item}`;
+    }
+
+    if (!map.has(item)) {
+      map.set(item, counter++);
+      return id(item);
+    }
+    return "id" + map.get(item);
+  }
+
+  return id;
+}
+
+function createSource() {
+  return {
+    value: 1,
+    id: generateUID()
+  };
+}


### PR DESCRIPTION
This addresses a bug found in https://github.com/reach/reach-ui/issues/193 where useId updating from null to its initial value after the first render appears to cause some jank with tooltips. I've updated the re-pro case to test the new implementation, which renders the correct ID without an initial null value. I also spun up a quick test in Next.js to ensure consistent behavior on SSR. 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
