### PR TITLE
Avoid extra render

### DIFF
--- a/packages/auto-id/src/index.js
+++ b/packages/auto-id/src/index.js
@@ -1,4 +1,4 @@
-import { useState, useEffect } from "react";
+import { useMemo } from "react";
 
 // Could use UUID but if we hit 9,007,199,254,740,991 unique components over
 // the lifetime of the app before it gets reloaded, I mean ... come on.
@@ -6,10 +6,7 @@ import { useState, useEffect } from "react";
 // /me googles
 // Oh duh, quadrillion. Nine quadrillion components. I think we're okay.
 let id = 0;
-const genId = () => ++id;
 
 export const useId = () => {
-  const [id, setId] = useState(null);
-  useEffect(() => setId(genId()), []);
-  return id;
+  return useMemo(() => id++, [])
 };


### PR DESCRIPTION
Technically this is a side effect outside 
a `useEffect`, but it avoids the extra render
triggered by the `setState` of the current implementation

One use case in which the extra render is bad is for example when wrapping an external library
```
function Editor() {
	const id = useId()
	const editorId = `editor_${id}`
	useEffect(() => {
		const editor = new ExampleJQueryEditor(editorId)
	}) 
	
	return <div id={editorId} />
}
```

Not sure if this will cause issues in concurrent mode.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.js` entry file
  - [ ] Type definitions in an `index.d.ts` file are desired but not required for the PR to be merged
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
