### PR TITLE
Export Slider* constants for use in user code

### DIFF
--- a/packages/slider/examples/vertical.example.js
+++ b/packages/slider/examples/vertical.example.js
@@ -5,13 +5,14 @@ import {
   SliderHandle,
   SliderMarker,
   SliderTrack,
-  SliderTrackHighlight
+  SliderTrackHighlight,
+  SliderOrientationVertical
 } from "@reach/slider";
 
 export const name = "Vertical";
 
 export const Example = () => (
-  <Slider orientation="vertical">
+  <Slider orientation={SliderOrientationVertical}>
     <SliderTrack>
       <SliderTrackHighlight />
       <SliderHandle />

--- a/packages/slider/examples/with-steps.example.js
+++ b/packages/slider/examples/with-steps.example.js
@@ -16,6 +16,7 @@ export const Example = () => {
   const max = 120;
   const range = max - min;
   const steps = Array.from(Array(range / step + 1).keys());
+
   return (
     <Slider step={step} min={min} max={max}>
       <SliderTrack>

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -29,18 +29,14 @@ import { wrapEvent, assignRef } from "@reach/utils";
 //    our slider on par. We'll explore animated and multi-handle sliders next.
 //  - We may want to research some use cases for reversed sliders in RTL languages if that's a thing
 
-const SliderOrientation = {
-  horizontal: "horizontal",
-  vertical: "vertical"
-};
+export const SliderOrientationHorizontal = "horizontal";
+export const SliderOrientationVertical = "vertical";
 
-const HandleAlignment = {
-  // Handle is centered directly over the current value marker
-  center: "center",
-  // Handle is contained within the bounds of the track, offset slightlu from the value's
-  // center mark to accommodate
-  contain: "contain"
-};
+// Handle is centered directly over the current value marker
+export const SliderHandleAlignCenter = "center";
+// Handle is contained within the bounds of the track, offset
+// slightly from the value's center mark to accommodate
+export const SliderHandleAlignContain = "contain";
 
 const SliderContext = createContext({});
 const useSliderContext = () => useContext(SliderContext);
@@ -55,7 +51,7 @@ export const Slider = forwardRef(function Slider(
     disabled,
     value: controlledValue,
     getValueText,
-    handleAlignment = HandleAlignment.center,
+    handleAlignment = SliderHandleAlignCenter,
     id,
     max = 100,
     min = 0,
@@ -65,7 +61,7 @@ export const Slider = forwardRef(function Slider(
     onPointerDown,
     onPointerMove,
     onPointerUp,
-    orientation = SliderOrientation.horizontal,
+    orientation = SliderOrientationHorizontal,
     step: stepProp,
     children,
     ...rest
@@ -101,7 +97,7 @@ export const Slider = forwardRef(function Slider(
   const _value = isControlled ? controlledValue : value;
   const actualValue = getAllowedValue(_value, min, max);
   const trackPercent = valueToPercent(actualValue, min, max);
-  const isVertical = orientation === SliderOrientation.vertical;
+  const isVertical = orientation === SliderOrientationVertical;
   const step = stepProp || 1;
 
   const handleSize = isVertical
@@ -109,7 +105,7 @@ export const Slider = forwardRef(function Slider(
     : handleDimensions.width;
 
   const handlePosition = `calc(${trackPercent}% - ${
-    handleAlignment === HandleAlignment.center
+    handleAlignment === SliderHandleAlignCenter
       ? `${handleSize}px / 2`
       : `${handleSize}px * ${trackPercent * 0.01}`
   })`;
@@ -340,13 +336,13 @@ if (__DEV__) {
     defaultValue: number,
     disabled: bool,
     getValueText: func,
-    handleAlignment: oneOf([HandleAlignment.center, HandleAlignment.contain]),
+    handleAlignment: oneOf([SliderHandleAlignCenter, SliderHandleAlignContain]),
     min: number,
     max: number,
     name: string,
     orientation: oneOf([
-      SliderOrientation.horizontal,
-      SliderOrientation.vertical
+      SliderOrientationHorizontal,
+      SliderOrientationVertical
     ]),
     onChange: func,
     children: oneOfType([node, func]).isRequired,


### PR DESCRIPTION
So people can use a constant instead of e.g. the string "vertical".

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other