### PR TITLE
MenuButton: accept pass-through props on outer menu component

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -95,7 +95,7 @@ const getInitialMenuState = () => ({
 
 const checkIfStylesIncluded = () => checkStyles("menu-button");
 
-const Menu = ({ children }) => {
+const Menu = ({ children, ...props }) => {
   return (
     <Component
       getRefs={getMenuRefs}
@@ -105,7 +105,7 @@ const Menu = ({ children }) => {
       getSnapshotBeforeUpdate={checkIfAppManagedFocus}
     >
       {context => (
-        <MenuContext.Provider value={{ ...context }}>
+        <MenuContext.Provider value={{ ...context, wrapperProps: props }}>
           {typeof children === "function"
             ? children({ isOpen: context.state.isOpen })
             : children}
@@ -329,7 +329,7 @@ if (__DEV__) {
 const MenuList = React.forwardRef((props, forwardedRef) => {
   const ownRef = React.useRef(null);
   const ref = ownRef || forwardedRef;
-  const { state } = React.useContext(MenuContext);
+  const { state, wrapperProps } = React.useContext(MenuContext);
   return (
     state.isOpen && (
       <Portal>
@@ -341,6 +341,7 @@ const MenuList = React.forwardRef((props, forwardedRef) => {
                   data-reach-menu
                   ref={menuRef}
                   style={getStyles(state.buttonRect, menuRect)}
+                  {...wrapperProps}
                 >
                   <MenuListImpl {...props} ref={ref} />
                 </div>


### PR DESCRIPTION
This presents a non-breaking alternative solution to https://github.com/reach/reach-ui/pull/148. Props passed to the `Menu` component will be passed through to the outer `reach-menu` that is rendered in the portal when the menu is visible.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other