### PR TITLE
Fix tooltips flicker

### DIFF
--- a/packages/tooltip/examples/with-dialog.example.js
+++ b/packages/tooltip/examples/with-dialog.example.js
@@ -1,0 +1,48 @@
+/* eslint-disable jsx-a11y/accessible-emoji */
+import "../styles.css";
+
+import React from "react";
+import { Dialog } from "@reach/dialog";
+import Tooltip from "@reach/tooltip";
+
+export const name = "With Dialog";
+
+export function Example() {
+  const [showDialog, setShowDialog] = React.useState(false);
+  return (
+    <div>
+      <button onClick={() => setShowDialog(true)}>Show Dialog</button>
+
+      <Dialog isOpen={showDialog}>
+        <div>
+          <Tooltip label="Notifications">
+            <button style={{ fontSize: 25 }}>
+              <span aria-hidden>🔔</span>
+            </button>
+          </Tooltip>
+          <Tooltip label="Settings">
+            <button style={{ fontSize: 25 }}>
+              <span aria-hidden>⚙️</span>
+            </button>
+          </Tooltip>
+          <Tooltip label="Your files are safe with us">
+            <button style={{ fontSize: 25 }}>
+              <span aria-hidden>💾</span> Save
+            </button>
+          </Tooltip>
+
+          <div style={{ float: "right" }}>
+            <Tooltip label="Notifications" ariaLabel="3 Notifications">
+              <button style={{ fontSize: 25 }}>
+                <span>🔔</span>
+                <span>3</span>
+              </button>
+            </Tooltip>
+          </div>
+        </div>
+
+        <button onClick={() => setShowDialog(false)}>Close Dialog</button>
+      </Dialog>
+    </div>
+  );
+}

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -224,6 +224,8 @@ function clearContextId() {
   context.id = null;
 }
 
+const domId = id => `tooltip-${id}`;
+
 ////////////////////////////////////////////////////////////////////////////////
 // THE HOOK! It's about time we got to the goods!
 export function useTooltip({
@@ -237,9 +239,14 @@ export function useTooltip({
   ref,
   DEBUG_STYLE
 } = {}) {
-  const id = `tooltip:${useId()}`;
+  const id = useId();
+
   const [isVisible, setIsVisible] = useState(
-    DEBUG_STYLE ? true : context.id === id && state === VISIBLE
+    DEBUG_STYLE
+      ? true
+      : id === null
+      ? false
+      : context.id === id && state === VISIBLE
   );
 
   // hopefully they always pass a ref if they ever pass one
@@ -335,7 +342,7 @@ export function useTooltip({
   };
 
   const trigger = {
-    "aria-describedby": isVisible ? id : undefined,
+    "aria-describedby": isVisible ? domId(id) : undefined,
     "data-reach-tooltip-trigger": "",
     ref: triggerRef,
     onMouseEnter: wrapEvent(onMouseEnter, handleMouseEnter),
@@ -423,7 +430,7 @@ export const TooltipPopup = forwardRef(function TooltipPopup(
         ariaLabel={ariaLabel}
         position={position}
         isVisible={isVisible}
-        id={id}
+        id={domId(id)}
         triggerRect={triggerRect}
         ref={forwardRef}
         {...rest}


### PR DESCRIPTION
Also, added another example with tooltips rendering inside a modal to try to replicate more closely the bug described by @bvaughn in #193.

Note: It was suggested in #193 that the bug was in the auto-id package since it provides `null` ids on the initial render. According to @ryanflorence this behavior is intentional. auto-id is not supposed to provide ids on the initial render because of the non-deterministic nature of server-rendered apps. Instead, they are supposed to be applied only _after_ the initial render, to be used by screen readers.

Fixes #193
Closes #293

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other