### PR TITLE
Import styles as users do in examples

### DIFF
--- a/.storybook/webpack.config.js
+++ b/.storybook/webpack.config.js
@@ -1,34 +1,18 @@
+const fs = require("fs");
 const path = require("path");
 
+const packagesDir = path.resolve(__dirname, "../packages");
+const packages = fs.readdirSync(packagesDir);
+
+const alias = packages.reduce((memo, pkg) => {
+  memo[`@reach/${pkg}`] = path.join(packagesDir, pkg);
+  return memo;
+}, {});
+
 module.exports = ({ config }) => {
-  const packagesPath = path.resolve(__dirname, "../packages");
   config.resolve = {
     ...config.resolve,
-    alias: {
-      "@reach/alert": path.join(packagesPath, "/alert/src/"),
-      "@reach/alert-dailog": path.join(packagesPath, "/alert-dailog/src/"),
-      "@reach/auto-id": path.join(packagesPath, "/auto-id/src/"),
-      "@reach/combobox": path.join(packagesPath, "/combobox/src/"),
-      "@reach/component-component": path.join(
-        packagesPath,
-        "/component-component/src/"
-      ),
-      "@reach/dailog": path.join(packagesPath, "/dailog/src/"),
-      "@reach/menu-button": path.join(packagesPath, "/menu-button/src/"),
-      "@reach/popover": path.join(packagesPath, "/popover/src/"),
-      "@reach/portal": path.join(packagesPath, "/portal/src/"),
-      "@reach/rect": path.join(packagesPath, "/rect/src/"),
-      "@reach/skip-nav": path.join(packagesPath, "/skip-nav/src/"),
-      "@reach/slider": path.join(packagesPath, "/slider/src/"),
-      "@reach/tabs": path.join(packagesPath, "/tabs/src/"),
-      "@reach/tooltip": path.join(packagesPath, "/tooltip/src/"),
-      "@reach/utils": path.join(packagesPath, "/utils/src/"),
-      "@reach/visually-hidden": path.join(
-        packagesPath,
-        "/visually-hidden/src/"
-      ),
-      "@reach/window-size": path.join(packagesPath, "/window-size/src/")
-    },
+    alias: alias,
     extensions: [".js"]
   };
   return config;

--- a/packages/alert-dialog/examples/basic.example.js
+++ b/packages/alert-dialog/examples/basic.example.js
@@ -1,16 +1,15 @@
-import React from "react";
-import "@reach/dialog/styles.css";
+import React, { useRef, useState } from "react";
 import {
   AlertDialog,
   AlertDialogLabel,
   AlertDialogDescription
-} from "../src/index";
+} from "@reach/alert-dialog";
 
 export let name = "Basic";
 
 export let Example = () => {
-  const close = React.useRef(null);
-  const [showDialog, setShowDialog] = React.useState(false);
+  const close = useRef(null);
+  const [showDialog, setShowDialog] = useState(false);
   return (
     <div>
       <button onClick={() => setShowDialog(true)}>Show Dialog</button>

--- a/packages/alert/examples/basic.example.js
+++ b/packages/alert/examples/basic.example.js
@@ -1,7 +1,8 @@
 import React from "react";
 import Alert from "@reach/alert";
 import VisuallyHidden from "@reach/visually-hidden";
-import LoremIpsum from "./LoremIpsum";
+
+import LoremIpsum from "./LoremIpsum.js";
 
 export let name = "Basic";
 

--- a/packages/combobox/examples/basic.example.js
+++ b/packages/combobox/examples/basic.example.js
@@ -1,4 +1,5 @@
-import "../styles.css";
+import "@reach/combobox/styles.css";
+
 import React, { useState, useMemo } from "react";
 import {
   Combobox,
@@ -9,7 +10,8 @@ import {
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
-import cities from "./cities";
+
+import cities from "./cities.js";
 
 export let name = "Basic";
 

--- a/packages/combobox/examples/controlled.example.js
+++ b/packages/combobox/examples/controlled.example.js
@@ -1,4 +1,5 @@
-import "../styles.css";
+import "@reach/combobox/styles.css";
+
 import React, { useState, useMemo, useRef } from "react";
 import {
   Combobox,
@@ -9,7 +10,8 @@ import {
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
-import cities from "./cities";
+
+import cities from "./cities.js";
 
 export let name = "Controlled";
 

--- a/packages/combobox/examples/lots-of-elements.example.js
+++ b/packages/combobox/examples/lots-of-elements.example.js
@@ -1,4 +1,5 @@
-import "../styles.css";
+import "@reach/combobox/styles.css";
+
 import React, { useState, useMemo } from "react";
 import {
   Combobox,
@@ -9,7 +10,8 @@ import {
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
-import cities from "./cities";
+
+import cities from "./cities.js";
 
 export let name = "Lots of Elements";
 

--- a/packages/combobox/examples/no-popover.example.js
+++ b/packages/combobox/examples/no-popover.example.js
@@ -1,4 +1,5 @@
-import "../styles.css";
+import "@reach/combobox/styles.css";
+
 import React, { useState, useMemo } from "react";
 import {
   Combobox,
@@ -9,7 +10,8 @@ import {
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
-import cities from "./cities";
+
+import cities from "./cities.js";
 
 export let name = "No Popover";
 

--- a/packages/combobox/examples/token-input.js
+++ b/packages/combobox/examples/token-input.js
@@ -1,4 +1,5 @@
-import "../styles.css";
+import "@reach/combobox/styles.css";
+
 import React, {
   useContext,
   useState,
@@ -14,11 +15,12 @@ import {
   ComboboxList,
   ComboboxOption,
   ComboboxPopover
-} from "../src/index";
+} from "@reach/combobox";
+import { wrapEvent } from "@reach/utils";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
-import cities from "./cities";
-import { wrapEvent } from "@reach/utils";
+
+import cities from "./cities.js";
 
 export let name = "Controlled";
 

--- a/packages/combobox/examples/with-button.example.js
+++ b/packages/combobox/examples/with-button.example.js
@@ -1,4 +1,5 @@
-import "../styles.css";
+import "@reach/combobox/styles.css";
+
 import React, { useState, useMemo } from "react";
 import {
   Combobox,
@@ -10,7 +11,8 @@ import {
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
-import cities from "./cities";
+
+import cities from "./cities.js";
 
 export let name = "With Button";
 

--- a/packages/dialog/examples/aria-hides-content.example.js
+++ b/packages/dialog/examples/aria-hides-content.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Dialog } from "@reach/dialog";
 

--- a/packages/dialog/examples/autofocus.example.js
+++ b/packages/dialog/examples/autofocus.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Dialog } from "@reach/dialog";
 
 export let name = "Autofocus";

--- a/packages/dialog/examples/basic.example.js
+++ b/packages/dialog/examples/basic.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Dialog } from "@reach/dialog";
 
 export let name = "Basic";

--- a/packages/dialog/examples/change-styles.example.js
+++ b/packages/dialog/examples/change-styles.example.js
@@ -1,7 +1,8 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
 import { useTransition, animated, config } from "react-spring/web.cjs";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
-import "../styles.css";
 
 export let name = "Change Styles";
 

--- a/packages/dialog/examples/destroy-trigger.example.js
+++ b/packages/dialog/examples/destroy-trigger.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Dialog } from "@reach/dialog";
 
 export let name = "Destroy Trigger";

--- a/packages/dialog/examples/dismiss.example.js
+++ b/packages/dialog/examples/dismiss.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Dialog } from "@reach/dialog";
 
 export let name = "Dismiss";

--- a/packages/dialog/examples/dropdown.example.js
+++ b/packages/dialog/examples/dropdown.example.js
@@ -1,8 +1,10 @@
+import "@reach/menu-button/styles.css";
+import "@reach/dialog/styles.css";
+
 import React from "react";
+import { action } from "@storybook/addon-actions";
 import { Menu, MenuButton, MenuList, MenuItem } from "@reach/menu-button";
 import { Dialog } from "@reach/dialog";
-import { action } from "@storybook/addon-actions";
-import "../styles.css";
 
 export let name = "Dropdown";
 

--- a/packages/dialog/examples/long-content.example.js
+++ b/packages/dialog/examples/long-content.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Dialog } from "@reach/dialog";
 
 export let name = "Long Content";

--- a/packages/dialog/examples/nested.example.js
+++ b/packages/dialog/examples/nested.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Dialog } from "@reach/dialog";
 
 export let name = "Nested";

--- a/packages/dialog/examples/no-tabbables.example.js
+++ b/packages/dialog/examples/no-tabbables.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Dialog } from "@reach/dialog";
 

--- a/packages/dialog/examples/with-dialog-overlay.example.js
+++ b/packages/dialog/examples/with-dialog-overlay.example.js
@@ -1,5 +1,6 @@
+import "@reach/dialog/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
 
 export let name = "With Separate Overlay";

--- a/packages/menu-button/examples/basic.example.js
+++ b/packages/menu-button/examples/basic.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "@reach/menu-button";
 

--- a/packages/menu-button/examples/conditional-items.example.js
+++ b/packages/menu-button/examples/conditional-items.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React, { useState } from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "@reach/menu-button";
 

--- a/packages/menu-button/examples/long-text.example.js
+++ b/packages/menu-button/examples/long-text.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import {
   Menu,

--- a/packages/menu-button/examples/non-menu-children.example.js
+++ b/packages/menu-button/examples/non-menu-children.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "@reach/menu-button";
 

--- a/packages/menu-button/examples/render-prop.example.js
+++ b/packages/menu-button/examples/render-prop.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "@reach/menu-button";
 

--- a/packages/menu-button/examples/with-links.example.js
+++ b/packages/menu-button/examples/with-links.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import {
   Menu,

--- a/packages/menu-button/examples/with-other-tabbables.example.js
+++ b/packages/menu-button/examples/with-other-tabbables.example.js
@@ -1,5 +1,6 @@
+import "@reach/menu-button/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "@reach/menu-button";
 

--- a/packages/menu-button/examples/with-tooltip.example.js
+++ b/packages/menu-button/examples/with-tooltip.example.js
@@ -1,10 +1,11 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
+import "@reach/menu-button/styles.css";
+import "@reach/tooltip/styles.css";
 
 import React from "react";
-import "../styles.css";
 import { action } from "@storybook/addon-actions";
 import { Menu, MenuList, MenuButton, MenuItem } from "@reach/menu-button";
-import Tooltip from "../../tooltip";
+import Tooltip from "@reach/tooltip";
 
 export let name = "With Tooltip";
 

--- a/packages/slider/examples/basic.example.js
+++ b/packages/slider/examples/basic.example.js
@@ -1,5 +1,6 @@
+import "@reach/slider/styles.css";
+
 import React from "react";
-import "../styles.css";
 import {
   Slider,
   SliderHandle,

--- a/packages/slider/examples/contained-handle.example.js
+++ b/packages/slider/examples/contained-handle.example.js
@@ -1,5 +1,6 @@
+import "@reach/slider/styles.css";
+
 import React from "react";
-import "../styles.css";
 import {
   Slider,
   SliderHandle,

--- a/packages/slider/examples/controlled-audio-progress.example.js
+++ b/packages/slider/examples/controlled-audio-progress.example.js
@@ -1,12 +1,14 @@
+import "@reach/slider/styles.css";
+
 import React from "react";
-import "../styles.css";
 import {
   Slider,
   SliderHandle,
   SliderTrack,
   SliderTrackHighlight
 } from "@reach/slider";
-import { useAudio, timeToMs, msToTime } from "./utils";
+
+import { useAudio, timeToMs, msToTime } from "./utils.js";
 
 export const name = "Audio Progress";
 

--- a/packages/slider/examples/controlled.example.js
+++ b/packages/slider/examples/controlled.example.js
@@ -1,5 +1,6 @@
+import "@reach/slider/styles.css";
+
 import React from "react";
-import "../styles.css";
 import {
   Slider,
   SliderHandle,

--- a/packages/slider/examples/vertical.example.js
+++ b/packages/slider/examples/vertical.example.js
@@ -1,5 +1,6 @@
+import "@reach/slider/styles.css";
+
 import React from "react";
-import "../styles.css";
 import {
   Slider,
   SliderHandle,

--- a/packages/slider/examples/with-steps.example.js
+++ b/packages/slider/examples/with-steps.example.js
@@ -1,5 +1,6 @@
+import "@reach/slider/styles.css";
+
 import React from "react";
-import "../styles.css";
 import {
   Slider,
   SliderHandle,

--- a/packages/slider/examples/with-tooltip.example.js
+++ b/packages/slider/examples/with-tooltip.example.js
@@ -1,7 +1,9 @@
+import "@reach/tooltip/styles.css";
+import "@reach/slider/styles.css";
+
 import React from "react";
-import { useTooltip, TooltipPopup } from "@reach/tooltip";
 import { wrapEvent } from "@reach/utils";
-import "../styles.css";
+import { useTooltip, TooltipPopup } from "@reach/tooltip";
 import {
   Slider,
   SliderHandle,

--- a/packages/tabs/examples/animated-bar.example.js
+++ b/packages/tabs/examples/animated-bar.example.js
@@ -1,3 +1,5 @@
+import "@reach/tabs/styles.css";
+
 import React, {
   useState,
   useRef,
@@ -5,7 +7,6 @@ import React, {
   useLayoutEffect,
   createContext
 } from "react";
-import "../styles.css";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 import { useRect } from "@reach/rect";
 

--- a/packages/tabs/examples/basic.example.js
+++ b/packages/tabs/examples/basic.example.js
@@ -1,5 +1,6 @@
+import "@reach/tabs/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 
 export const name = "Basic";

--- a/packages/tabs/examples/controlled.example.js
+++ b/packages/tabs/examples/controlled.example.js
@@ -1,5 +1,6 @@
+import "@reach/tabs/styles.css";
+
 import React, { useState } from "react";
-import "../styles.css";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 
 export const name = "Controlled";

--- a/packages/tabs/examples/disabled.example.js
+++ b/packages/tabs/examples/disabled.example.js
@@ -1,5 +1,6 @@
+import "@reach/tabs/styles.css";
+
 import React from "react";
-import "../styles.css";
 import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
 
 export const name = "Disabled Tabs";

--- a/packages/tooltip/examples/animated.example.js
+++ b/packages/tooltip/examples/animated.example.js
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
-import "../styles.css";
+import "@reach/tooltip/styles.css";
+
 import React, { Fragment, cloneElement } from "react";
 import { useTooltip, TooltipPopup } from "@reach/tooltip";
 // https://github.com/react-spring/react-spring/issues/552#issuecomment-464680114

--- a/packages/tooltip/examples/basic.example.js
+++ b/packages/tooltip/examples/basic.example.js
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
-import "../styles.css";
+import "@reach/tooltip/styles.css";
+
 import React from "react";
 import Tooltip from "@reach/tooltip";
 

--- a/packages/tooltip/examples/triangle.example.js
+++ b/packages/tooltip/examples/triangle.example.js
@@ -1,5 +1,6 @@
 /* eslint-disable jsx-a11y/accessible-emoji */
-import "../styles.css";
+import "@reach/tooltip/styles.css";
+
 import React, { Fragment, cloneElement } from "react";
 import { useTooltip, TooltipPopup } from "@reach/tooltip";
 

--- a/packages/tooltip/examples/with-disabled-button.example.js
+++ b/packages/tooltip/examples/with-disabled-button.example.js
@@ -1,7 +1,7 @@
-/* eslint-disable jsx-a11y/accessible-emoji */
-import "../styles.css";
+import "@reach/tooltip/styles.css";
+
 import React from "react";
-import Tooltip from "../src/index";
+import Tooltip from "@reach/tooltip";
 
 export const name = "With Disabled Button";
 


### PR DESCRIPTION
This should be the last of the relative `import`s in the examples.

I also added a few missing `import`s which were not obviously broken, but would be if someone tried to copy/paste our example into a vanilla app, e.g. when using _both_ a dialog and a tooltip in the same example you need both `@reach/dialog/styles.css` _and_ `@reach/tooltip/styles.css`. I'm guessing it wasn't broken before because storybook/webpack just bundles up everything into one huge bundle so the examples share deps.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other