### PR TITLE
Fix data attribute typo in alert dialog

### DIFF
--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -62,7 +62,7 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
   return (
     <DialogContent
       ref={forwardRef}
-      data-reach-alert-dialong-content
+      data-reach-alert-dialog-content
       role="alertdialog"
       aria-labelledby={labelId}
       {...props}


### PR DESCRIPTION
Adding this in its own PR, because it _could_ be treated as a breaking change? It's a small typo on `<DialogContent>`, but if a user is using that data attribute for styling, fixing the typo could result in breaking that user's styles.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
