### PR TITLE
Add solution to ignore css warning in jest tests

### DIFF
--- a/website/src/pages/styling.mdx
+++ b/website/src/pages/styling.mdx
@@ -40,6 +40,15 @@ Here's an example:
 }
 ```
 
+Skipping the 'missing CSS' warning with setting the css variable `--reach-dialog` will not work in your tests. If you are using jest you can skip them by mocking the function which is checking the styles.
+
+```
+jest.mock('@reach/utils', () => ({
+  ...jest.requireActual('@reach/utils'),
+  checkStyles: jest.fn(),
+}));
+```
+
 ## Using a Bundler (webpack, parcel, etc.)
 
 If you are using a module bundler like webpack or parcel, you can import them where you import the component.


### PR DESCRIPTION
This pull request updates documentation or example code.

The additional information will hopefully help people to find the solution faster than searching in the Github issues.

---
related to https://github.com/reach/reach-ui/issues/136