### PR TITLE
Fix Tooltip TypeScript definition

### DIFF
--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -38,7 +38,7 @@ declare module "@reach/tooltip" {
     children?: React.ReactNode;
   } & BaseTooltipProps;
 
-  declare const Tooltip: React.FunctionComponent<TooltipProps>;
+  const Tooltip: React.FunctionComponent<TooltipProps>;
   export const TooltipPopup: React.FunctionComponent<TooltipPopupProps>;
   export const TooltipContent: React.FunctionComponent<BaseTooltipProps>;
   export default Tooltip;


### PR DESCRIPTION

This pull request:

- [x] Fixes a bug in an existing package

The types shipped with the tooltip result in 
`A 'declare' modifier cannot be used in an already ambient context.`

Removing the nested `declare` fixed the above error.

