### PR TITLE
Fix examples using animated translate values

### DIFF
--- a/packages/dialog/examples/change-styles.example.js
+++ b/packages/dialog/examples/change-styles.example.js
@@ -27,7 +27,9 @@ export const Example = () => {
               <AnimatedDialogContent
                 aria-labelledby="dialog-title"
                 style={{
-                  transform: `translate3d(0px, ${styles.y}px, 0px)`,
+                  transform: styles.y.interpolate(
+                    value => `translate3d(0px, ${value}px, 0px)`
+                  ),
                   border: "4px solid hsla(0, 0%, 0%, 0.5)",
                   borderRadius: 10
                 }}

--- a/website/src/pages/animation.mdx
+++ b/website/src/pages/animation.mdx
@@ -122,7 +122,7 @@ function Example(props) {
             <AnimatedDialogOverlay style={{ opacity: styles.opacity }}>
               <AnimatedDialogContent
                 style={{
-                  transform: `translate3d(0px, ${styles.y}px, 0px)`,
+                  transform: styles.y.interpolate((value) => `translate3d(0px, ${value}px, 0px)`),
                   border: "4px solid hsla(0, 0%, 0%, 0.5)",
                   borderRadius: 10
                 }}

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -494,7 +494,7 @@ function Example(props) {
       <p>This might take a while! Are you sure?</p>
       <button>Go Forward</button> <button>Go Back</button>
     </Dialog>
-  );
+  )
 }
 ```
 
@@ -502,14 +502,14 @@ function Example(props) {
 
 ```jsx
 function Example(props) {
-  const labelId = `label:${useId()}`;
+  const labelId = `label:${useId()}`
   return (
     <Dialog aria-labelledby={labelId} isOpen={true}>
       <h1 id={labelId}>Next Steps</h1>
       <p>Follow these steps carefully!</p>
       <button>Go Forward</button> <button>Go Back</button>
     </Dialog>
-  );
+  )
 }
 ```
 

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -449,7 +449,7 @@ function Example(props) {
             <AnimatedDialogOverlay style={{ opacity: styles.opacity }}>
               <AnimatedDialogContent
                 style={{
-                  transform: `translate3d(0px, ${styles.y}px, 0px)`,
+                  transform: styles.y.interpolate((value) => `translate3d(0px, ${value}px, 0px)`),
                   border: "4px solid hsla(0, 0%, 0%, 0.5)",
                   borderRadius: 10
                 }}
@@ -494,7 +494,7 @@ function Example(props) {
       <p>This might take a while! Are you sure?</p>
       <button>Go Forward</button> <button>Go Back</button>
     </Dialog>
-  )
+  );
 }
 ```
 
@@ -502,14 +502,14 @@ function Example(props) {
 
 ```jsx
 function Example(props) {
-  const labelId = `label:${useId()}`
+  const labelId = `label:${useId()}`;
   return (
     <Dialog aria-labelledby={labelId} isOpen={true}>
       <h1 id={labelId}>Next Steps</h1>
       <p>Follow these steps carefully!</p>
       <button>Go Forward</button> <button>Go Back</button>
     </Dialog>
-  )
+  );
 }
 ```
 


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other


---

Hi! 

First PR to this repo, hope it helps.

**What:**
This PR updates (& fixes) examples on the website and storybook that uses transform/translate3d values and `react-spring`. When using `transform` you have to use the `interpolate` function rather than setting the value directly with css, or the transform style will be ignored.

**How to verify:**
Test the animated dialog example or the "Change styles" dialog example in storybook. With this fix, the transform should work (in master these examples just animate opacity, not transform).

**HELP**
I'm not sure why `website/yarn.lock` updated, I assume it wasn't up to date with the latest changes in other packages? I couldn't get the website to build on master. If you could help me understand why that is (just me or something currently broken?) that would be great.