### PR TITLE
Make visually hidden render as span

### DIFF
--- a/packages/visually-hidden/src/index.js
+++ b/packages/visually-hidden/src/index.js
@@ -12,7 +12,7 @@ let style = {
 };
 
 function VisuallyHidden(props) {
-  return <div style={style} {...props} />;
+  return <span style={style} {...props} />;
 }
 
 export default VisuallyHidden;


### PR DESCRIPTION
Refer to SO question: https://stackoverflow.com/questions/12982269/is-it-semantically-incorrect-to-put-a-div-or-span-inside-of-a-button/12982334

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
