### PR TITLE
[@reach/dialog] add `allowPinchZoom` prop to TypeScript definition

### DIFF
--- a/packages/dialog/index.d.ts
+++ b/packages/dialog/index.d.ts
@@ -45,6 +45,12 @@ export type DialogProps = {
  */
 export type DialogOverlayProps = {
   /**
+   * Allow two-finger zoom gestures on iOS devices
+   *
+   * @see Docs https://github.com/reach/reach-ui/issues/325
+   */
+  allowPinchZoom?: boolean;
+  /**
    * By default the first focusable element will receive focus when the dialog
    * opens but you can provide a ref to focus instead.
    *


### PR DESCRIPTION
This pull request:

- [x] Fixes a bug in an existing package

Attempting to use the `allowPinchZoom` prop on `<DialogOverlay>` results in the following TypeScript error:
> Property 'allowPinchZoom' does not exist on type [...]