### PR TITLE
Fix @reach/tooltip type definition

### DIFF
--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -54,7 +54,7 @@ declare const Tooltip: React.FunctionComponent<TooltipProps>;
 /**
  * @see Docs https://reacttraining.com/reach-ui/tooltip#tooltippopup
  */
-declare const TooltipPopup: React.FunctionComponent<TooltipPopupProps>;
+export const TooltipPopup: React.FunctionComponent<TooltipPopupProps>;
 
 /**
  * @see Docs https://reacttraining.com/reach-ui/tooltip#tooltipcontent


### PR DESCRIPTION
Export `TooltipPopup` from type definition.

resolves #351 

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
