### PR TITLE
[@reach/tabs] Remove TabsProps generic type unused parameter

### DIFF
--- a/packages/tabs/index.d.ts
+++ b/packages/tabs/index.d.ts
@@ -29,10 +29,9 @@ type SupportedTabsComponent = object | keyof JSX.IntrinsicElements;
 /**
  * @see Docs https://reacttraining.com/reach-ui/tabs#tabs-props
  */
-export type TabsProps<T extends SupportedTabsComponent> = Omit<
-  ResolvedTabsProps<T>,
-  "onChange"
-> & {
+export type TabsProps<
+  T extends SupportedTabsComponent = SupportedTabsComponent
+> = Omit<ResolvedTabsProps<T>, "onChange"> & {
   /**
    * Tabs expects `<TabList>` and `<TabPanels>` as children. The order doesn't
    * matter, you can have tabs on the top or the bottom. In fact, you could have


### PR DESCRIPTION
This pull request:

- [x] Fixes a bug in an existing package

## Why?

I am currently getting a blocking TS issue `Generic type 'TabsProps' requires 1 type argument(s).`
It seems that the TabsProps type had an unused parameter, I can reproduce when I copy/paste the `index.d.ts` file into the TS playground.

My version of Typescript: v3.2.4

## Solution
I removed the parameter here, but maybe I am wrong. Do you see a better fix?