### PR TITLE
[@reach/tabs] Decouple UI Hierarchy with Context

### DIFF
--- a/packages/tabs/examples/animated-bar.example.js
+++ b/packages/tabs/examples/animated-bar.example.js
@@ -5,7 +5,14 @@ import React, {
   useLayoutEffect,
   createContext
 } from "react";
-import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
+import {
+  Tabs,
+  TabList,
+  Tab,
+  TabPanels,
+  TabPanel,
+  useTabState
+} from "@reach/tabs";
 import { useRect } from "@reach/rect";
 import "@reach/tabs/styles.css";
 
@@ -39,7 +46,7 @@ function ExampleAnimatedTabs({ color, ...rest }) {
 }
 
 function ExampleAnimatedTab(props) {
-  const { isSelected } = props;
+  const { isSelected } = useTabState();
 
   // measure the size of our element, only listen to rect if active
   const ref = useRef();

--- a/packages/tabs/examples/with-non-tabs-components-interweaved.example.js
+++ b/packages/tabs/examples/with-non-tabs-components-interweaved.example.js
@@ -1,0 +1,52 @@
+import "@reach/tabs/styles.css";
+
+import React from "react";
+import { Tabs, TabList, Tab, TabPanels, TabPanel } from "@reach/tabs";
+
+export const name = "With Non-Tabs Components Interweaved";
+
+const tabsStyle = {
+  width: 400,
+  boxShadow: "1px 1px 5px hsla(0, 0%, 0%, 0.25)"
+};
+
+const tabListWrapperStyle = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "space-between",
+  border: "1px solid darkslategray",
+  padding: "4px 0"
+};
+
+export const Example = () => (
+  <Tabs style={tabsStyle}>
+    <div style={tabListWrapperStyle}>
+      <TabList style={{ margin: "0 16px" }}>
+        <Tab>One</Tab>
+        <Tab>Two</Tab>
+        <Tab>Three</Tab>
+      </TabList>
+      <div style={{ margin: "0 16px", textAlign: "right" }}>
+        Here is content styled alongside the tab list
+      </div>
+    </div>
+
+    <div style={{ background: "ghostwhite", padding: "16px" }}>
+      <div style={{ textAlign: "center" }}>
+        Here is content above tab panels but styled with it.
+      </div>
+      <TabPanels>
+        <TabPanel>
+          <h1>one!</h1>
+          <button>yo</button>
+        </TabPanel>
+        <TabPanel>
+          <h1>two!</h1>
+        </TabPanel>
+        <TabPanel>
+          <h1>three!</h1>
+        </TabPanel>
+      </TabPanels>
+    </div>
+  </Tabs>
+);

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -75,29 +75,32 @@ export const Tabs = forwardRef(function Tabs(
 
   const [selectedIndex, setSelectedIndex] = useState(defaultIndex || 0);
 
+  const tabsContext = React.useMemo(
+    () => ({
+      selectedIndex: isControlled ? controlledIndex : selectedIndex,
+      _id: id,
+      _userInteractedRef,
+      _selectedPanelRef,
+      _onFocusPanel: () =>
+        _selectedPanelRef.current && _selectedPanelRef.current.focus(),
+      _onSelectTab: readOnly
+        ? () => {}
+        : index => {
+            _userInteractedRef.current = true;
+            onChange && onChange(index);
+            if (!isControlled) {
+              setSelectedIndex(index);
+            }
+          }
+    }),
+    [id, controlledIndex, isControlled, onChange, readOnly, selectedIndex]
+  );
+
   useEffect(() => checkStyles("tabs"), []);
 
   return (
     <Comp data-reach-tabs="" ref={ref} {...props}>
-      <TabsContext.Provider
-        value={{
-          selectedIndex: isControlled ? controlledIndex : selectedIndex,
-          _id: id,
-          _userInteractedRef,
-          _selectedPanelRef,
-          _onFocusPanel: () =>
-            _selectedPanelRef.current && _selectedPanelRef.current.focus(),
-          _onSelectTab: readOnly
-            ? () => {}
-            : index => {
-                _userInteractedRef.current = true;
-                onChange && onChange(index);
-                if (!isControlled) {
-                  setSelectedIndex(index);
-                }
-              }
-        }}
-      >
+      <TabsContext.Provider value={tabsContext}>
         {children}
       </TabsContext.Provider>
     </Comp>

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -28,6 +28,15 @@ const TabsContext = createNamedContext("Tabs");
 const TabContext = createNamedContext("Tab");
 const TabPanelContext = createNamedContext("TabPanel");
 
+export const useTabState = () => {
+  const index = useContext(TabContext);
+  const { selectedIndex } = useContext(TabsContext);
+
+  return {
+    isSelected: index === selectedIndex
+  };
+};
+
 ////////////////////////////////////////////////////////////////////////////////
 // Tabs
 


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.js` entry file
  - [ ] Type definitions in an `index.d.ts` file are desired but not required for the PR to be merged
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)

## Tabs: Now with Context

`<Tabs>` and its constituents have now been built using [Context] instead of `cloneElement`, which relieves the direct parent-child restriction of the current implementation for `<Tabs>/<TabList>` and `<Tabs>/<TabPanels>` *. It also now exposes [styling state] with a `useTabState` [hook].

### Motivation

> NOTE: this is influenced from the _Implicit State with Compound Components and Context_ [lecture] video, the [Reach UI Philosophy Guide], and my own experience working with `<Tabs>`.

The current `<Tabs>` is great, but suffers a limitation in which all of its components must have a direct parent-child relationship. But what if you want to insert other components in between?

```jsx
<Tabs>
  <div className="this-breaks-tabs">
    <TabList>
      <Tab />
    </TabList>
  </div>

  <div className="also-breaks-tabs">
    <TabPanels>
      <TabPanel />
    </TabPanels>
  </div>
</Tabs>
```
By adding a couple seemingly innocuous divs we lose the active tab indicator and click handler functionality.

Or what if we want to add sibling elements to the tab list or tab panels?

```jsx
<Tabs>
  <TabList>
    <Tab />
  </TabList>

  {/* The div below would be passed unnecessary props from Tabs when cloned … whoops! */}
  <div className="foo">Some sibling content to tab list and tab panels</div>

  <TabPanels>
    <TabPanel />
  </TabPanels>
</Tabs>
```

We start passing [Tabs-specific props] to native (or composite) components that shouldn't have those additional props!

For both situations, using context allows us to decouple that UI hierarchy.

---

\* It's worth noting that this PR doesn't remove the necessity for the direct parent-child relationship between `<TabList>` and each `<Tab>` as well as `<TabPanels>` and each `<TabPanel>`. In order to know which tab is active, we have to know about the order of each `<Tab>` and `<TabPanel>` (currently using its index as a direct child). In order to decouple this relationship it would likely require significantly more overhaul with a kind of context registering. One solution could be to have each `<Tab>` and `<TabPanel>` call some register function (passed down to them through TabContext) when they mount, and the context provider would return the index to the child.

UPDATE: I've created a separate commit that removes the necessity for the direct parent-child relationship between `<TabList>` and each `<Tab>` as well as `<TabPanels>` and each `<TabPanel>`. You can see what these changes would look like [here](https://github.com/indiesquidge/reach-ui/compare/tabs-with-context...indiesquidge:tabs-with-context-part-2?expand=1). (Please read the commit message in the PR description to note the caveats this approach would have when React running in [Concurrent Mode].)

[Context]: https://reactjs.org/docs/context.html
[styling state]: https://gist.github.com/ryanflorence/e5c794e6093d16a69fa88d2112a292f7#styling-states-with-pseudo-pseudo-selectors
[hook]: https://gist.github.com/ryanflorence/e5c794e6093d16a69fa88d2112a292f7#exposing-state-for-js-styling
[lecture]: https://courses.reacttraining.com/courses/250055/lectures/3897321
[Reach UI Philosophy Guide]: https://gist.github.com/ryanflorence/e5c794e6093d16a69fa88d2112a292f7
[Concurrent Mode]: https://reactjs.org/docs/concurrent-mode-intro.html
[Tabs-specific props]: https://github.com/reach/reach-ui/blob/c20cdf7f2dd6b9eabe5461138daf320e2833aa41/packages/tabs/src/index.js#L45-L64
