### PR TITLE
Include @reach/utils types when publishing to npm

### DIFF
--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -17,6 +17,7 @@
     "es",
     "src",
     "lib",
-    "index.js"
+    "index.js",
+    "index.d.ts"
   ]
 }


### PR DESCRIPTION
This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

I started using this package at work and noticed that the types exist here but aren't being published to npm with the package. If they were intentionally left out, feel free to close this. If it was an accident, I believe this should do the trick.

Thanks!
