### PR TITLE
Accept ID as prop to fix deterministic ID issues

### DIFF
--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -8,12 +8,13 @@ import { func, bool, node, object, oneOfType } from "prop-types";
 let AlertDialogContext = createContext({});
 
 export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
-  { leastDestructiveRef, ...props },
+  { leastDestructiveRef, id: idProp, ...props },
   forwardRef
 ) {
   const uid = useId();
-  const labelId = makeId("alert-dialog", uid);
-  const descriptionId = makeId("alert-dialog-description", uid);
+  const id = idProp || uid;
+  const labelId = makeId("alert-dialog", id);
+  const descriptionId = makeId("alert-dialog-description", id);
 
   return (
     <AlertDialogContext.Provider
@@ -24,6 +25,7 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
       }}
     >
       <DialogOverlay
+        id={idProp}
         ref={forwardRef}
         data-reach-alert-dialog-overlay
         initialFocusRef={leastDestructiveRef}

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -8,10 +8,10 @@ import { func, bool, node, object, oneOfType } from "prop-types";
 let AlertDialogContext = createContext({});
 
 export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
-  { leastDestructiveRef, id: idProp, ...props },
+  { leastDestructiveRef, ...props },
   forwardRef
 ) {
-  const id = useId(idProp);
+  const id = useId(props.id);
   const labelId = makeId("alert-dialog", id);
   const descriptionId = makeId("alert-dialog-description", id);
 
@@ -24,7 +24,6 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
       }}
     >
       <DialogOverlay
-        id={idProp}
         ref={forwardRef}
         data-reach-alert-dialog-overlay
         initialFocusRef={leastDestructiveRef}

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -11,8 +11,7 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
   { leastDestructiveRef, id: idProp, ...props },
   forwardRef
 ) {
-  const uid = useId();
-  const id = idProp || uid;
+  const id = useId(idProp);
   const labelId = makeId("alert-dialog", id);
   const descriptionId = makeId("alert-dialog-description", id);
 

--- a/packages/auto-id/index.d.ts
+++ b/packages/auto-id/index.d.ts
@@ -7,4 +7,4 @@
  *
  * @see Docs https://reacttraining.com/reach-ui/auto-id
  */
-export const useId: () => number;
+export const useId: (hasFallback?: string) => number;

--- a/packages/auto-id/src/index.js
+++ b/packages/auto-id/src/index.js
@@ -50,24 +50,15 @@ const genId = () => ++id;
 
 export const useId = fallback => {
   /*
-   * We'll check for a fallback and use that if it is provided.
-   * React doesn't like us to call hooks conditionally, so no early bailout.
-   */
-  const hasFallback = fallback && typeof fallback === "string";
-  /*
    * If this instance isn't part of the initial render, we don't have to do the
    * double render/patch-up dance. We can just generate the ID and return it.
    */
-  const initialId = hasFallback
-    ? fallback
-    : serverHandoffComplete
-    ? genId()
-    : null;
+  const initialId = fallback || serverHandoffComplete ? genId() : null;
 
   const [id, setId] = useState(initialId);
 
   useLayoutEffect(() => {
-    if (!hasFallback && id === null) {
+    if (id === null) {
       /*
        * Patch the ID after render. We do this in `useLayoutEffect` to avoid any
        * rendering flicker, though it'll make the first render slower (unlikely
@@ -77,7 +68,7 @@ export const useId = fallback => {
       setId(genId());
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [hasFallback]);
+  }, []);
 
   useEffect(() => {
     if (serverHandoffComplete === false) {

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -1,6 +1,3 @@
-/* eslint-disable jsx-a11y/role-has-required-aria-props */
-/* eslint-disable jsx-a11y/aria-proptypes */
-/* eslint-disable jsx-a11y/role-supports-aria-props */
 /* eslint-disable default-case */
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -24,7 +21,7 @@ import React, {
   useState
 } from "react";
 import { func } from "prop-types";
-import { wrapEvent, useForkedRef } from "@reach/utils";
+import { makeId, wrapEvent, useForkedRef } from "@reach/utils";
 import { findAll } from "highlight-words-core";
 import escapeRegexp from "escape-regexp";
 import { useId } from "@reach/auto-id";
@@ -210,6 +207,7 @@ export const Combobox = forwardRef(function Combobox(
   {
     // Called whenever the user selects an item from the list
     onSelect,
+    id: idProp,
 
     // opens the list when the input receives focused (but only if there are
     // items in the list)
@@ -262,7 +260,9 @@ export const Combobox = forwardRef(function Combobox(
 
   useFocusManagement(data.lastActionType, inputRef);
 
-  const listboxId = `listbox--${useId()}`;
+  const uid = useId();
+  const id = idProp || uid;
+  const listboxId = makeId("listbox", id);
 
   const context = useMemo(() => {
     return {
@@ -293,6 +293,7 @@ export const Combobox = forwardRef(function Combobox(
         aria-haspopup="listbox"
         aria-owns={listboxId}
         aria-expanded={context.isVisible}
+        id={idProp}
       >
         {children}
       </Comp>
@@ -356,6 +357,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
   useLayoutEffect(() => {
     autocompletePropRef.current = autocomplete;
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autocomplete]);
 
   const handleValueChange = value => {
@@ -661,6 +663,7 @@ function useFocusManagement(lastActionType, inputRef) {
     ) {
       inputRef.current.focus();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastActionType]);
 }
 

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -260,8 +260,7 @@ export const Combobox = forwardRef(function Combobox(
 
   useFocusManagement(data.lastActionType, inputRef);
 
-  const uid = useId();
-  const id = idProp || uid;
+  const id = useId(idProp);
   const listboxId = makeId("listbox", id);
 
   const context = useMemo(() => {

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -207,7 +207,6 @@ export const Combobox = forwardRef(function Combobox(
   {
     // Called whenever the user selects an item from the list
     onSelect,
-    id: idProp,
 
     // opens the list when the input receives focused (but only if there are
     // items in the list)
@@ -260,7 +259,7 @@ export const Combobox = forwardRef(function Combobox(
 
   useFocusManagement(data.lastActionType, inputRef);
 
-  const id = useId(idProp);
+  const id = useId(rest.id);
   const listboxId = makeId("listbox", id);
 
   const context = useMemo(() => {
@@ -292,7 +291,6 @@ export const Combobox = forwardRef(function Combobox(
         aria-haspopup="listbox"
         aria-owns={listboxId}
         aria-expanded={context.isVisible}
-        id={idProp}
       >
         {children}
       </Comp>

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -132,8 +132,7 @@ export const SliderInput = forwardRef(function SliderInput(
     "Slider is changing from uncontrolled to controlled. Slider should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Slider for the lifetime of the component. Check the `value` prop being passed in."
   );
 
-  const uid = useId();
-  const id = idProp || uid;
+  const id = useId(idProp);
 
   const trackRef = useRef(null);
   const handleRef = useRef(null);

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -102,7 +102,6 @@ export const SliderInput = forwardRef(function SliderInput(
     value: controlledValue,
     getValueText,
     handleAlignment = SLIDER_HANDLE_ALIGN_CENTER,
-    id: idProp,
     max = 100,
     min = 0,
     name,
@@ -132,7 +131,7 @@ export const SliderInput = forwardRef(function SliderInput(
     "Slider is changing from uncontrolled to controlled. Slider should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Slider for the lifetime of the component. Check the `value` prop being passed in."
   );
 
-  const id = useId(idProp);
+  const id = useId(rest.id);
 
   const trackRef = useRef(null);
   const handleRef = useRef(null);
@@ -347,7 +346,6 @@ export const SliderInput = forwardRef(function SliderInput(
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
         aria-disabled={disabled}
-        id={idProp}
         {...dataAttributes}
         {...rest}
       >

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -102,7 +102,7 @@ export const SliderInput = forwardRef(function SliderInput(
     value: controlledValue,
     getValueText,
     handleAlignment = SLIDER_HANDLE_ALIGN_CENTER,
-    id,
+    id: idProp,
     max = 100,
     min = 0,
     name,
@@ -132,7 +132,8 @@ export const SliderInput = forwardRef(function SliderInput(
     "Slider is changing from uncontrolled to controlled. Slider should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Slider for the lifetime of the component. Check the `value` prop being passed in."
   );
 
-  const _id = makeId("slider", useId());
+  const uid = useId();
+  const id = idProp || uid;
 
   const trackRef = useRef(null);
   const handleRef = useRef(null);
@@ -272,8 +273,6 @@ export const SliderInput = forwardRef(function SliderInput(
 
   const valueText = getValueText ? getValueText(value) : ariaValueText;
 
-  const sliderId = id || _id;
-
   const trackHighlightStyle = isVertical
     ? {
         width: `100%`,
@@ -298,7 +297,7 @@ export const SliderInput = forwardRef(function SliderInput(
     onPointerUp,
     onHandleKeyDown: handleKeyDown,
     setHasFocus,
-    sliderId,
+    sliderId: id,
     sliderMax: max,
     sliderMin: min,
     value,
@@ -349,14 +348,14 @@ export const SliderInput = forwardRef(function SliderInput(
         onPointerDown={handlePointerDown}
         onPointerUp={handlePointerUp}
         aria-disabled={disabled}
-        id={sliderId}
+        id={idProp}
         {...dataAttributes}
         {...rest}
       >
         {typeof children === "function"
           ? children({
               hasFocus,
-              id: sliderId,
+              id,
               max,
               min,
               value,
@@ -372,7 +371,7 @@ export const SliderInput = forwardRef(function SliderInput(
             type="hidden"
             value={value}
             name={name}
-            id={makeId("input", sliderId)}
+            id={makeId("input", id)}
           />
         )}
       </div>

--- a/packages/tabs/src/__snapshots__/index.test.js.snap
+++ b/packages/tabs/src/__snapshots__/index.test.js.snap
@@ -11,7 +11,7 @@ exports[`rendering focuses the correct tab with keyboard navigation 1`] = `
         role="tablist"
       >
         <button
-          aria-controls="panel--2--0"
+          aria-controls="panel--3--0"
           aria-selected="false"
           data-reach-tab=""
           id="tab-1"
@@ -22,7 +22,7 @@ exports[`rendering focuses the correct tab with keyboard navigation 1`] = `
           Tab One
         </button>
         <button
-          aria-controls="panel--2--1"
+          aria-controls="panel--3--1"
           aria-selected="true"
           data-reach-tab=""
           data-selected=""
@@ -34,7 +34,7 @@ exports[`rendering focuses the correct tab with keyboard navigation 1`] = `
           Tab Two
         </button>
         <button
-          aria-controls="panel--2--2"
+          aria-controls="panel--3--2"
           aria-selected="false"
           data-reach-tab=""
           id="tab-3"
@@ -49,10 +49,10 @@ exports[`rendering focuses the correct tab with keyboard navigation 1`] = `
         data-reach-tab-panels=""
       >
         <div
-          aria-labelledby="tab--2--0"
+          aria-labelledby="tab--3--0"
           data-reach-tab-panel=""
           hidden=""
-          id="panel--2--0"
+          id="panel--3--0"
           role="tabpanel"
           tabindex="-1"
         >
@@ -64,9 +64,9 @@ exports[`rendering focuses the correct tab with keyboard navigation 1`] = `
           </button>
         </div>
         <div
-          aria-labelledby="tab--2--1"
+          aria-labelledby="tab--3--1"
           data-reach-tab-panel=""
-          id="panel--2--1"
+          id="panel--3--1"
           role="tabpanel"
           tabindex="-1"
         >
@@ -75,10 +75,10 @@ exports[`rendering focuses the correct tab with keyboard navigation 1`] = `
           </h1>
         </div>
         <div
-          aria-labelledby="tab--2--2"
+          aria-labelledby="tab--3--2"
           data-reach-tab-panel=""
           hidden=""
-          id="panel--2--2"
+          id="panel--3--2"
           role="tabpanel"
           tabindex="-1"
         >

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -31,8 +31,7 @@ export const Tabs = forwardRef(function Tabs(
     "Tabs is changing from uncontrolled to controlled. Tabs should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Tabs for the lifetime of the component. Check the `index` prop being passed in."
   );
 
-  const uid = useId();
-  const id = idProp || uid;
+  const id = useId(idProp);
 
   // we only manage focus if the user caused the update vs.
   // a new controlled index coming in

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -11,6 +11,7 @@ export const Tabs = forwardRef(function Tabs(
     as: Comp = "div",
     onChange,
     index: controlledIndex = undefined,
+    id: idProp,
     readOnly = false,
     defaultIndex,
     ...props
@@ -30,7 +31,8 @@ export const Tabs = forwardRef(function Tabs(
     "Tabs is changing from uncontrolled to controlled. Tabs should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Tabs for the lifetime of the component. Check the `index` prop being passed in."
   );
 
-  const _id = useId();
+  const uid = useId();
+  const id = idProp || uid;
 
   // we only manage focus if the user caused the update vs.
   // a new controlled index coming in
@@ -45,7 +47,7 @@ export const Tabs = forwardRef(function Tabs(
     if (!child || typeof child.type === "string") return child;
     return cloneElement(child, {
       selectedIndex: isControlled ? controlledIndex : selectedIndex,
-      _id,
+      _id: id,
       _userInteractedRef,
       _selectedPanelRef,
       _onFocusPanel: () =>
@@ -62,7 +64,15 @@ export const Tabs = forwardRef(function Tabs(
     });
   });
 
-  return <Comp data-reach-tabs="" ref={ref} {...props} children={clones} />;
+  return (
+    <Comp
+      data-reach-tabs=""
+      ref={ref}
+      id={idProp}
+      {...props}
+      children={clones}
+    />
+  );
 });
 
 if (__DEV__) {

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -11,7 +11,6 @@ export const Tabs = forwardRef(function Tabs(
     as: Comp = "div",
     onChange,
     index: controlledIndex = undefined,
-    id: idProp,
     readOnly = false,
     defaultIndex,
     ...props
@@ -31,7 +30,7 @@ export const Tabs = forwardRef(function Tabs(
     "Tabs is changing from uncontrolled to controlled. Tabs should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Tabs for the lifetime of the component. Check the `index` prop being passed in."
   );
 
-  const id = useId(idProp);
+  const id = useId(props.id);
 
   // we only manage focus if the user caused the update vs.
   // a new controlled index coming in
@@ -63,15 +62,7 @@ export const Tabs = forwardRef(function Tabs(
     });
   });
 
-  return (
-    <Comp
-      data-reach-tabs=""
-      ref={ref}
-      id={idProp}
-      {...props}
-      children={clones}
-    />
-  );
+  return <Comp data-reach-tabs="" ref={ref} {...props} children={clones} />;
 });
 
 if (__DEV__) {

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -227,6 +227,7 @@ function clearContextId() {
 ////////////////////////////////////////////////////////////////////////////////
 // THE HOOK! It's about time we got to the goods!
 export function useTooltip({
+  id: idProp,
   onMouseEnter,
   onMouseMove,
   onMouseLeave,
@@ -237,7 +238,8 @@ export function useTooltip({
   ref: forwardedRef,
   DEBUG_STYLE
 } = {}) {
-  const id = useId();
+  const uid = useId();
+  const id = idProp || uid;
 
   const [isVisible, setIsVisible] = useState(
     DEBUG_STYLE
@@ -362,13 +364,13 @@ export function useTooltip({
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-function Tooltip({ children, label, ariaLabel, DEBUG_STYLE, ...rest }) {
+function Tooltip({ children, label, ariaLabel, id, DEBUG_STYLE, ...rest }) {
   const child = Children.only(children);
 
   // We need to pass some properties from the child into useTooltip
   // to make sure users can maintain control over the trigger's ref and events
   const [trigger, tooltip] = useTooltip({
-    DEBUG_STYLE,
+    id,
     onMouseEnter: child.props.onMouseEnter,
     onMouseMove: child.props.onMouseMove,
     onMouseLeave: child.props.onMouseLeave,
@@ -376,7 +378,8 @@ function Tooltip({ children, label, ariaLabel, DEBUG_STYLE, ...rest }) {
     onBlur: child.props.onBlur,
     onKeyDown: child.props.onKeyDown,
     onMouseDown: child.props.onMouseDown,
-    ref: child.ref
+    ref: child.ref,
+    DEBUG_STYLE
   });
   return (
     <Fragment>

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -238,8 +238,7 @@ export function useTooltip({
   ref: forwardedRef,
   DEBUG_STYLE
 } = {}) {
-  const uid = useId();
-  const id = idProp || uid;
+  const id = useId(idProp);
 
   const [isVisible, setIsVisible] = useState(
     DEBUG_STYLE

--- a/website/src/pages/auto-id.mdx
+++ b/website/src/pages/auto-id.mdx
@@ -15,6 +15,8 @@ import Helmet from "../components/DefaultHelmet";
 
 Autogenerate IDs to facilitate WAI-ARIA and server rendering.
 
+A string can be supplied as an argument to be used in lieu of the auto-generated ID. This is handy for accepting user-provided prop IDs that need to be deterministic.
+
 ## Installation
 
 ```bash
@@ -28,5 +30,6 @@ yarn add @reach/auto-id
 ```js
 import { useId } from "@reach/auto-id";
 
-const id = `tooltip:${useId()}`;
+// Pass in a user-supplied ID that will be used conditionally if provided
+const id = useId(props.id);
 ```

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -502,7 +502,7 @@ function Example(props) {
 
 ```jsx
 function Example(props) {
-  const labelId = `label:${useId()}`;
+  const labelId = `label--${useId(props.id)}`;
   return (
     <Dialog aria-labelledby={labelId} isOpen={true}>
       <h1 id={labelId}>Next Steps</h1>


### PR DESCRIPTION
The general approach here boils down to this: anywhere we are generating a UID with `useId`, we need to give the developer a way to pass a ID prop into the top-level component as an alternative. This will be used as a root ID string so that all descendant component IDs will be deterministic.

We may still choose to, eventually, allow nested component IDs to be passed directly, but at the moment this adds more complexity than it's worth. So long as a user can specify a root ID, they should be able to do whatever they want with children.