### PR TITLE
Fix issues with how IDs are handled

### DIFF
--- a/packages/alert-dialog/examples/id-prop.example.js
+++ b/packages/alert-dialog/examples/id-prop.example.js
@@ -1,0 +1,53 @@
+import React, { useRef, useState } from "react";
+import {
+  AlertDialogOverlay,
+  AlertDialogContent,
+  AlertDialogLabel,
+  AlertDialogDescription
+} from "@reach/alert-dialog";
+
+export let name = "ID Props";
+
+export function Example() {
+  const [showDialog, setShowDialog] = useState(false);
+
+  // we'll pass this ref to both AlertDialog and our button
+  const cancelRef = useRef();
+
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
+    <div>
+      <button onClick={open}>Delete something</button>
+
+      {showDialog && (
+        <AlertDialogOverlay
+          style={{ background: "hsla(0, 50%, 50%, 0.85)" }}
+          leastDestructiveRef={cancelRef}
+          id="myAlertDialogOverlay"
+        >
+          <AlertDialogContent
+            id="myAlertDialogContent"
+            style={{ background: "#f0f0f0" }}
+          >
+            <AlertDialogLabel id="myAlertDialogLabel">
+              Please Confirm!
+            </AlertDialogLabel>
+
+            <AlertDialogDescription id="myAlertDialogDescription">
+              Are you sure you want delete stuff, it will be permanent.
+            </AlertDialogDescription>
+
+            <div className="alert-buttons">
+              <button onClick={close}>Yes, delete</button>{" "}
+              <button ref={cancelRef} onClick={close}>
+                Nevermind
+              </button>
+            </div>
+          </AlertDialogContent>
+        </AlertDialogOverlay>
+      )}
+    </div>
+  );
+}

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -11,7 +11,8 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
   forwardRef
 ) {
   // generate a label ID, but allow it to be overwritten by setting an ID on <AlertDialogLabel>
-  const [labelId, setLabelId] = useState(useId("alert-dialog-label"));
+  const uid = useId("alert-dialog-label");
+  const [labelId, setLabelId] = useState(uid || "alert-dialog-label");
   // don't set immediately, since <AlertDialogDescription> is not required
   const [descriptionId, setDescriptionId] = useState();
 

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -92,10 +92,7 @@ export const AlertDialogLabel = ({ id, ...props }) => {
 };
 
 export const AlertDialogDescription = props => {
-  const descriptionId = useId("alert-dialog-description");
-  return (
-    <div id={descriptionId} data-reach-alert-dialog-description {...props} />
-  );
+  return <div data-reach-alert-dialog-description {...props} />;
 };
 
 export const AlertDialog = ({

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -11,9 +11,8 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
   { leastDestructiveRef, ...props },
   forwardRef
 ) {
-  const uid = useId();
-  const labelId = makeId("alert-dialog", uid);
-  const descriptionId = makeId("alert-dialog-description", uid);
+  const labelId = useId("alert-dialog");
+  const descriptionId = useId("alert-dialog-description");
 
   return (
     <AlertDialogContext.Provider

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -86,7 +86,9 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
         https://ui.reach.tech/alert-dialog/#alertdialogoverlay-leastdestructiveref`
     );
 
-    return clearTimeout(timer.current);
+    return () => {
+      clearTimeout(timer.current);
+    };
   }, [
     labelId,
     leastDestructiveRef,

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -1,7 +1,6 @@
 import React, { createContext, useState, useEffect, useRef } from "react";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
 import { useId } from "@reach/auto-id";
-import { makeId } from "@reach/utils";
 import invariant from "invariant";
 import { func, bool, node, object, oneOfType } from "prop-types";
 

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -56,7 +56,8 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
   const ariaDescribedBy = props["aria-describedby"] || descriptionId;
   const timer = useRef();
   React.useEffect(() => {
-    // defer these checks for 1 tick to allow <AlertDialogLabel> to update labelId via context
+    // defer these checks for 1 tick to allow <AlertDialogLabel> and
+    // <AlertDialogDescription> to update their labels via context
     timer.current = setTimeout(() => {
       invariant(
         document.getElementById(labelId),

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -12,13 +12,11 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
   forwardRef
 ) {
   const labelId = useId("alert-dialog");
-  const descriptionId = useId("alert-dialog-description");
 
   return (
     <AlertDialogContext.Provider
       value={{
         labelId,
-        descriptionId,
         leastDestructiveRef
       }}
     >
@@ -86,7 +84,7 @@ export const AlertDialogLabel = props => {
 };
 
 export const AlertDialogDescription = props => {
-  const { descriptionId } = React.useContext(AlertDialogContext);
+  const descriptionId = useId("alert-dialog-description");
   return (
     <div id={descriptionId} data-reach-alert-dialog-description {...props} />
   );

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -1,4 +1,4 @@
-import React, { createContext } from "react";
+import React, { createContext, useState, useEffect } from "react";
 import { DialogOverlay, DialogContent } from "@reach/dialog";
 import { useId } from "@reach/auto-id";
 import { makeId } from "@reach/utils";
@@ -11,12 +11,14 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
   { leastDestructiveRef, ...props },
   forwardRef
 ) {
-  const labelId = useId("alert-dialog");
+  // generate a label ID, but allow it to be overwritten by setting an ID on <AlertDialogLabel>
+  const [labelId, setLabelId] = useState(useId("alert-dialog"));
 
   return (
     <AlertDialogContext.Provider
       value={{
         labelId,
+        setLabelId,
         leastDestructiveRef
       }}
     >
@@ -78,8 +80,14 @@ if (__DEV__) {
   };
 }
 
-export const AlertDialogLabel = props => {
-  const { labelId } = React.useContext(AlertDialogContext);
+export const AlertDialogLabel = ({ id, ...props }) => {
+  const { labelId, setLabelId } = React.useContext(AlertDialogContext);
+  useEffect(() => {
+    // if we've set id on label, notify AlertDialogContent
+    if (id) {
+      setLabelId(id);
+    }
+  }, [id, setLabelId]);
   return <div id={labelId} data-reach-alert-dialog-label {...props} />;
 };
 

--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -52,8 +52,7 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
   const { labelId, leastDestructiveRef, descriptionId } = React.useContext(
     AlertDialogContext
   );
-  const ariaLabelledBy = props["aria-labelledby"] || labelId;
-  const ariaDescribedBy = props["aria-describedby"] || descriptionId;
+
   const timer = useRef();
   React.useEffect(() => {
     // defer these checks for 1 tick to allow <AlertDialogLabel> and
@@ -64,21 +63,6 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
         `@reach/alert-dialog: You must render a \`<AlertDialogLabel>\`
         inside an \`<AlertDialog/>\`.`
       );
-      invariant(
-        ariaLabelledBy === labelId,
-        `@reach/alert-dialog: User-defined \`aria-labelledby\` value must match
-      \`id\` set on \`<AlertDialogLabel>\`. Recieved \`aria-labelledby="${ariaLabelledBy}"\`,
-      \`labelId="${labelId}"\``
-      );
-
-      if (ariaDescribedBy) {
-        invariant(
-          ariaDescribedBy === descriptionId,
-          `@reach/alert-dialog: User-defined \`aria-describedby\` value must match
-        \`id\` set on \`<AlertDialogDescription>\`. Recieved \`aria-describedby="${ariaDescribedBy}"\`,
-        \`descriptionId="${descriptionId}"\``
-        );
-      }
     }, 1);
     invariant(
       leastDestructiveRef,
@@ -90,13 +74,7 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
     return () => {
       clearTimeout(timer.current);
     };
-  }, [
-    labelId,
-    leastDestructiveRef,
-    ariaLabelledBy,
-    ariaDescribedBy,
-    descriptionId
-  ]);
+  }, [labelId, leastDestructiveRef, descriptionId]);
   return (
     <DialogContent
       ref={forwardRef}
@@ -104,9 +82,9 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
       data-reach-alert-dialong-content
       data-reach-alert-dialog-content
       role="alertdialog"
-      aria-labelledby={ariaLabelledBy}
-      {...(ariaDescribedBy ? { "aria-describedby": ariaDescribedBy } : {})}
       {...props}
+      aria-labelledby={labelId}
+      {...(descriptionId ? { "aria-describedby": descriptionId } : {})}
     >
       {children}
     </DialogContent>

--- a/packages/auto-id/examples/basic.example.js
+++ b/packages/auto-id/examples/basic.example.js
@@ -1,0 +1,20 @@
+import React from "react";
+import "@reach/dialog/styles.css";
+import { useId } from "../src/index";
+
+export let name = "Basic";
+
+export let Example = () => {
+  const divId = `div:${useId()}`;
+  const buttonId = `div:${useId()}`;
+  return (
+    <>
+      <div id={divId}>
+        This element has an ID of <strong>{divId}</strong>
+      </div>
+      <button id={buttonId} onClick={() => false}>
+        This element has an ID of <strong>{buttonId}</strong>
+      </button>
+    </>
+  );
+};

--- a/packages/auto-id/examples/basic.example.js
+++ b/packages/auto-id/examples/basic.example.js
@@ -5,8 +5,8 @@ import { useId } from "../src/index";
 export let name = "Basic";
 
 export let Example = () => {
-  const divId = `div:${useId()}`;
-  const buttonId = `div:${useId()}`;
+  const divId = useId("div");
+  const buttonId = useId("button");
   return (
     <>
       <div id={divId}>

--- a/packages/auto-id/src/index.js
+++ b/packages/auto-id/src/index.js
@@ -48,12 +48,14 @@ let serverHandoffComplete = false;
 let id = 0;
 const genId = () => ++id;
 
-export const useId = () => {
+const combineId = (label, id) => (label ? `${label}_${id}` : id);
+
+export const useId = label => {
   /*
    * If this instance isn't part of the initial render, we don't have to do the
    * double render/patch-up dance. We can just generate the ID and return it.
    */
-  const initialId = serverHandoffComplete ? genId() : null;
+  const initialId = serverHandoffComplete ? combineId(label, genId()) : null;
 
   const [id, setId] = useState(initialId);
 
@@ -65,7 +67,7 @@ export const useId = () => {
        * to matter, but you're welcome to measure your app and let us know if
        * it's a problem).
        */
-      setId(genId());
+      setId(combineId(genId()));
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);

--- a/packages/combobox/examples/basic.example.js
+++ b/packages/combobox/examples/basic.example.js
@@ -27,7 +27,11 @@ export function Example() {
     <div>
       <h2>Clientside Search</h2>
       <Combobox>
-        <ComboboxInput onChange={handleChange} style={inputStyle} />
+        <ComboboxInput
+          onChange={handleChange}
+          style={inputStyle}
+          id="my-combobox-input"
+        />
         {results && (
           <ComboboxPopover style={popupStyle}>
             <p>
@@ -38,6 +42,7 @@ export function Example() {
                 <ComboboxOption
                   key={index}
                   value={`${result.city}, ${result.state}`}
+                  id={`option_${index}`}
                 />
               ))}
             </ComboboxList>

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -262,7 +262,8 @@ export const Combobox = forwardRef(function Combobox(
 
   useFocusManagement(data.lastActionType, inputRef);
 
-  const listboxId = `listbox--${useId()}`;
+  const defaultListboxId = useId("listbox");
+  const [listboxId, setListboxId] = useState(null);
 
   const context = useMemo(() => {
     return {

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -272,20 +272,17 @@ export const Combobox = forwardRef(function Combobox(
       inputRef,
       popoverRef,
       buttonRef,
-      onSelect,
-      optionsRef,
-      state,
-      transition,
+      isVisible: isVisible(state),
       listboxId,
       setListboxId,
-      autocompletePropRef,
+      onSelect,
+      optionsRef,
       persistSelectionRef,
-      inputIdDictionary,
-      isVisible: isVisible(state),
-      openOnFocus
+      state,
+      transition,
+      inputIdDictionary
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [data, onSelect, state, transition, listboxId]);
+  }, [data, state, listboxId, onSelect, transition]);
 
   return (
     <Context.Provider value={context}>
@@ -332,7 +329,6 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
     // might be controlled
     value: controlledValue,
-    id,
     ...props
   },
   forwardedRef
@@ -342,10 +338,6 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
     inputRef,
     state,
     transition,
-    listboxId,
-    setListboxId,
-    autocompletePropRef,
-    openOnFocus,
     inputIdDictionary
   } = useContext(Context);
 

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -264,8 +264,7 @@ export const Combobox = forwardRef(function Combobox(
 
   useFocusManagement(data.lastActionType, inputRef);
 
-  const defaultListboxId = useId("listbox");
-  const [listboxId, setListboxId] = useState(null);
+  const [listboxId, setListboxId] = useState(useId("listbox"));
 
   const context = useMemo(() => {
     return {
@@ -278,6 +277,7 @@ export const Combobox = forwardRef(function Combobox(
       state,
       transition,
       listboxId,
+      setListboxId,
       autocompletePropRef,
       persistSelectionRef,
       inputIdDictionary,
@@ -332,6 +332,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
     // might be controlled
     value: controlledValue,
+    id,
     ...props
   },
   forwardedRef
@@ -342,6 +343,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
     state,
     transition,
     listboxId,
+    setListboxId,
     autocompletePropRef,
     openOnFocus,
     inputIdDictionary
@@ -362,6 +364,12 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
   useLayoutEffect(() => {
     autocompletePropRef.current = autocomplete;
   }, [autocomplete]);
+
+  useLayoutEffect(() => {
+    if (id) {
+      setListboxId(id);
+    }
+  }, [id, setListboxId]);
 
   const handleValueChange = value => {
     if (value.trim() === "") {

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -24,7 +24,7 @@ import React, {
   useState
 } from "react";
 import { func } from "prop-types";
-import { makeId, wrapEvent, useForkedRef, assignRef } from "@reach/utils";
+import { makeId, wrapEvent, useForkedRef } from "@reach/utils";
 import { findAll } from "highlight-words-core";
 import escapeRegexp from "escape-regexp";
 import { useId } from "@reach/auto-id";
@@ -280,9 +280,11 @@ export const Combobox = forwardRef(function Combobox(
       persistSelectionRef,
       state,
       transition,
-      inputIdDictionary
+      inputIdDictionary,
+      openOnFocus,
+      autocompletePropRef
     };
-  }, [data, state, listboxId, onSelect, transition]);
+  }, [data, state, listboxId, onSelect, transition, openOnFocus]);
 
   return (
     <Context.Provider value={context}>
@@ -326,6 +328,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
     onKeyDown,
     onBlur,
     onFocus,
+    id,
 
     // might be controlled
     value: controlledValue,
@@ -338,7 +341,11 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
     inputRef,
     state,
     transition,
-    inputIdDictionary
+    inputIdDictionary,
+    autocompletePropRef,
+    openOnFocus,
+    setListboxId,
+    listboxId
   } = useContext(Context);
 
   const ref = useForkedRef(inputRef, forwardedRef);
@@ -355,7 +362,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
 
   useLayoutEffect(() => {
     autocompletePropRef.current = autocomplete;
-  }, [autocomplete]);
+  }, [autocomplete, autocompletePropRef]);
 
   useLayoutEffect(() => {
     if (id) {
@@ -674,7 +681,7 @@ function useFocusManagement(lastActionType, inputRef) {
     ) {
       inputRef.current.focus();
     }
-  }, [lastActionType]);
+  }, [inputRef, lastActionType]);
 }
 
 // We want the same events when the input or the popup have focus (HOW COOL ARE

--- a/packages/slider/examples/composed.example.js
+++ b/packages/slider/examples/composed.example.js
@@ -1,0 +1,26 @@
+import "@reach/slider/styles.css";
+
+import React from "react";
+import {
+  SliderMarker,
+  SliderInput,
+  SliderTrack,
+  SliderTrackHighlight,
+  SliderHandle
+} from "@reach/slider";
+
+export const name = "Composed of Parts";
+
+export function Example() {
+  return (
+    <div>
+      <SliderInput id="mySliderInput">
+        <SliderTrack id="mySliderTrack">
+          <SliderTrackHighlight id="mySliderTrackHighlight" />
+          <SliderMarker id="mySliderMarker" value={50} />
+          <SliderHandle id="mySliderHandle" />
+        </SliderTrack>
+      </SliderInput>
+    </div>
+  );
+}

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -132,7 +132,7 @@ export const SliderInput = forwardRef(function SliderInput(
     "Slider is changing from uncontrolled to controlled. Slider should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Slider for the lifetime of the component. Check the `value` prop being passed in."
   );
 
-  const _id = makeId("slider", useId());
+  const _id = useId("slider");
 
   const trackRef = useRef(null);
   const handleRef = useRef(null);
@@ -273,6 +273,7 @@ export const SliderInput = forwardRef(function SliderInput(
   const valueText = getValueText ? getValueText(value) : ariaValueText;
 
   const sliderId = id || _id;
+  const inputId = useId("sliderinput");
 
   const trackHighlightStyle = isVertical
     ? {
@@ -310,7 +311,8 @@ export const SliderInput = forwardRef(function SliderInput(
     trackPercent,
     trackRef,
     trackHighlightStyle,
-    updateValue
+    updateValue,
+    inputId
   };
 
   const dataAttributes = makeDataAttributes("slider", {
@@ -368,12 +370,7 @@ export const SliderInput = forwardRef(function SliderInput(
           // capture the value. We'll assume this when the component is given a
           // form field name (A `name` prop doesn't really make sense in any
           // other context).
-          <input
-            type="hidden"
-            value={value}
-            name={name}
-            id={makeId("input", sliderId)}
-          />
+          <input type="hidden" value={value} name={name} id={inputId} />
         )}
       </div>
     </SliderContext.Provider>
@@ -611,7 +608,7 @@ function makeDataAttributes(
   };
 }
 
-function useDimensions(passedRef) {
+export function useDimensions(passedRef) {
   const [{ width, height }, setDimensions] = useState({ width: 0, height: 0 });
   // Many existing `useDimensions` type hooks will use `getBoundingClientRect`
   // getBoundingClientRect does not work here when borders are applied.

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -11,6 +11,7 @@ export const Tabs = forwardRef(function Tabs(
     as: Comp = "div",
     onChange,
     index: controlledIndex = undefined,
+    id: idProp,
     readOnly = false,
     defaultIndex,
     ...props
@@ -30,7 +31,8 @@ export const Tabs = forwardRef(function Tabs(
     "Tabs is changing from uncontrolled to controlled. Tabs should not switch from uncontrolled to controlled (or vice versa). Decide between using a controlled or uncontrolled Tabs for the lifetime of the component. Check the `index` prop being passed in."
   );
 
-  const _id = useId();
+  const uid = useId();
+  const id = idProp || uid;
 
   // we only manage focus if the user caused the update vs.
   // a new controlled index coming in
@@ -45,7 +47,7 @@ export const Tabs = forwardRef(function Tabs(
     if (!child || typeof child.type === "string") return child;
     return cloneElement(child, {
       selectedIndex: isControlled ? controlledIndex : selectedIndex,
-      _id,
+      _id: id,
       _userInteractedRef,
       _selectedPanelRef,
       _onFocusPanel: () =>
@@ -62,7 +64,9 @@ export const Tabs = forwardRef(function Tabs(
     });
   });
 
-  return <Comp data-reach-tabs="" ref={ref} {...props} children={clones} />;
+  return (
+    <Comp data-reach-tabs="" id={id} ref={ref} {...props} children={clones} />
+  );
 });
 
 if (__DEV__) {
@@ -170,7 +174,7 @@ if (__DEV__) {
 
 ////////////////////////////////////////////////////////////////////////////////
 export const Tab = forwardRef(function Tab(
-  { children, as: Comp = "button", ...rest },
+  { children, as: Comp = "button", id: idProp, ...rest },
   forwardedRef
 ) {
   const { isSelected, _userInteractedRef, _onSelect, _id, ...htmlProps } = rest;
@@ -179,6 +183,8 @@ export const Tab = forwardRef(function Tab(
 
   const ownRef = useRef(null);
   const ref = useForkedRef(forwardedRef, ownRef);
+
+  const id = idProp || makeId("tab", _id);
 
   useUpdateEffect(() => {
     if (isSelected && ownRef.current && _userInteractedRef.current) {
@@ -192,7 +198,7 @@ export const Tab = forwardRef(function Tab(
       data-reach-tab=""
       ref={ref}
       role="tab"
-      id={makeId("tab", _id)}
+      id={id}
       tabIndex={isSelected ? 0 : -1}
       aria-selected={isSelected}
       aria-controls={makeId("panel", _id)}
@@ -252,11 +258,13 @@ if (__DEV__) {
 
 ////////////////////////////////////////////////////////////////////////////////
 export const TabPanel = forwardRef(function TabPanel(
-  { children, as: Comp = "div", ...rest },
+  { children, as: Comp = "div", id: idProp, ...rest },
   forwardedRef
 ) {
   const { isSelected, _selectedPanelRef, _id, ...htmlProps } = rest;
   const ref = useForkedRef(forwardedRef, isSelected ? _selectedPanelRef : null);
+
+  const id = idProp || makeId("panel", _id);
 
   return (
     <Comp
@@ -266,7 +274,7 @@ export const TabPanel = forwardRef(function TabPanel(
       tabIndex={-1}
       aria-labelledby={makeId("tab", _id)}
       hidden={!isSelected}
-      id={makeId("panel", _id)}
+      id={id}
       children={children}
       {...htmlProps}
     />

--- a/packages/tooltip/examples/basic.example.js
+++ b/packages/tooltip/examples/basic.example.js
@@ -10,7 +10,7 @@ export function Example() {
   const coolRef = React.useRef();
   return (
     <div>
-      <Tooltip label="Notifications">
+      <Tooltip label="Notifications" id="myTooltip">
         <button style={{ fontSize: 25 }} ref={coolRef}>
           <span aria-hidden>🔔</span>
         </button>

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -227,6 +227,7 @@ function clearContextId() {
 ////////////////////////////////////////////////////////////////////////////////
 // THE HOOK! It's about time we got to the goods!
 export function useTooltip({
+  id: idProp,
   onMouseEnter,
   onMouseMove,
   onMouseLeave,
@@ -237,7 +238,8 @@ export function useTooltip({
   ref: forwardedRef,
   DEBUG_STYLE
 } = {}) {
-  const id = useId("tooltip");
+  const uid = useId();
+  const id = idProp || uid;
 
   const [isVisible, setIsVisible] = useState(
     DEBUG_STYLE
@@ -362,12 +364,13 @@ export function useTooltip({
 }
 
 ////////////////////////////////////////////////////////////////////////////////
-function Tooltip({ children, label, ariaLabel, DEBUG_STYLE, ...rest }) {
+function Tooltip({ children, label, ariaLabel, id, DEBUG_STYLE, ...rest }) {
   const child = Children.only(children);
 
   // We need to pass some properties from the child into useTooltip
   // to make sure users can maintain control over the trigger's ref and events
   const [trigger, tooltip] = useTooltip({
+    id,
     DEBUG_STYLE,
     onMouseEnter: child.props.onMouseEnter,
     onMouseMove: child.props.onMouseMove,
@@ -384,6 +387,7 @@ function Tooltip({ children, label, ariaLabel, DEBUG_STYLE, ...rest }) {
       <TooltipPopup
         label={label}
         ariaLabel={ariaLabel}
+        id={id}
         {...tooltip}
         {...rest}
       />

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -237,7 +237,7 @@ export function useTooltip({
   ref: forwardedRef,
   DEBUG_STYLE
 } = {}) {
-  const id = useId();
+  const id = useId("tooltip");
 
   const [isVisible, setIsVisible] = useState(
     DEBUG_STYLE
@@ -340,7 +340,7 @@ export function useTooltip({
   };
 
   const trigger = {
-    "aria-describedby": isVisible ? makeId("tooltip", id) : undefined,
+    "aria-describedby": isVisible ? id : undefined,
     "data-reach-tooltip-trigger": "",
     ref,
     onMouseEnter: wrapEvent(onMouseEnter, handleMouseEnter),
@@ -425,7 +425,7 @@ export const TooltipPopup = forwardRef(function TooltipPopup(
         ariaLabel={ariaLabel}
         position={position}
         isVisible={isVisible}
-        id={makeId("tooltip", id)}
+        id={id}
         triggerRect={triggerRect}
         ref={forwardRef}
         {...rest}


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other


This started as a fix for #321

I debated creating this PR; it steps on the heels of #365 (basically overriding everything that that PR does). Ultimately I think it's worth it though, it handles some cases that #365 doesn't and allows some more elements to have custom IDs

In general, the idea is for elements where we have to know the ID (for `aria-*` attributes usually), we manage that ID in the parent and save it in state/context, then allow for it to be overridden in the child component.

@chancestrickland If you'd rather close this and concentrate on #365 that is fine; I just wanted to get it up there. I could offer some feedback based on this work over there if you would prefer that route.

