### PR TITLE
Fix typo in the yarn add command for Combobox

### DIFF
--- a/website/src/pages/combobox.mdx
+++ b/website/src/pages/combobox.mdx
@@ -32,7 +32,7 @@ A combobox is the combination of an `<input type="text"/>` and a list. The list 
 ```bash
 npm install @reach/combobox
 # or
-yarn add @reach/ombobox
+yarn add @reach/combobox
 ```
 
 And then import the components:


### PR DESCRIPTION
This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

Although very small, I noticed a small typo in the `yarn add @reach/combobox` command. This addresses it.