### PR TITLE
multiple packages: fix how prop-types is imported (fixes #375)

### DIFF
--- a/packages/alert-dialog/src/index.js
+++ b/packages/alert-dialog/src/index.js
@@ -3,7 +3,7 @@ import { DialogOverlay, DialogContent } from "@reach/dialog";
 import { useId } from "@reach/auto-id";
 import { makeId } from "@reach/utils";
 import invariant from "invariant";
-import { func, bool, node, object, oneOfType } from "prop-types";
+import PropTypes from "prop-types";
 
 let AlertDialogContext = createContext({});
 
@@ -35,10 +35,10 @@ export const AlertDialogOverlay = React.forwardRef(function AlertDialogOverlay(
 
 if (__DEV__) {
   AlertDialogOverlay.propTypes = {
-    isOpen: bool,
-    onDismiss: func,
-    leastDestructiveRef: oneOfType([func, object]),
-    children: node
+    isOpen: PropTypes.bool,
+    onDismiss: PropTypes.func,
+    leastDestructiveRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    children: PropTypes.node
   };
 }
 
@@ -77,7 +77,7 @@ export const AlertDialogContent = React.forwardRef(function AlertDialogContent(
 
 if (__DEV__) {
   AlertDialogContent.propTypes = {
-    children: node
+    children: PropTypes.node
   };
 }
 
@@ -99,16 +99,16 @@ export const AlertDialog = ({
   leastDestructiveRef,
   ...props
 }) => (
-  <AlertDialogOverlay {...{ isOpen, onDismiss, leastDestructiveRef }}>
-    <AlertDialogContent {...props} />
-  </AlertDialogOverlay>
-);
+    <AlertDialogOverlay {...{ isOpen, onDismiss, leastDestructiveRef }}>
+      <AlertDialogContent {...props} />
+    </AlertDialogOverlay>
+  );
 
 if (__DEV__) {
   AlertDialog.propTypes = {
-    isOpen: bool,
-    onDismiss: func,
-    leastDestructiveRef: oneOfType([func, object]),
-    children: node
+    isOpen: PropTypes.bool,
+    onDismiss: PropTypes.func,
+    leastDestructiveRef: PropTypes.oneOfType([PropTypes.func, PropTypes.object]),
+    children: PropTypes.node
   };
 }

--- a/packages/alert/src/index.js
+++ b/packages/alert/src/index.js
@@ -15,7 +15,7 @@ import React, { forwardRef, useEffect, useRef, useMemo } from "react";
 import { render } from "react-dom";
 import VisuallyHidden from "@reach/visually-hidden";
 import { usePrevious, useForkedRef } from "@reach/utils";
-import { node, string } from "prop-types";
+import PropTypes from "prop-types";
 
 // singleton state is fine because you don't server render
 // an alert (SRs don't read them on first load anyway)
@@ -56,8 +56,8 @@ const Alert = forwardRef(function Alert(
 
 if (__DEV__) {
   Alert.propTypes = {
-    children: node,
-    type: string
+    children: PropTypes.node,
+    type: PropTypes.string
   };
 }
 

--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -23,7 +23,7 @@ import React, {
   useReducer,
   useState
 } from "react";
-import { func } from "prop-types";
+import PropTypes from "prop-types";
 import { wrapEvent, useForkedRef } from "@reach/utils";
 import { findAll } from "highlight-words-core";
 import escapeRegexp from "escape-regexp";
@@ -302,7 +302,7 @@ export const Combobox = forwardRef(function Combobox(
 
 if (__DEV__) {
   Combobox.propTypes = {
-    onSelect: func
+    onSelect: PropTypes.func
   };
 }
 
@@ -405,7 +405,7 @@ export const ComboboxInput = forwardRef(function ComboboxInput(
   const inputValue =
     autocomplete && (state === NAVIGATING || state === INTERACTING)
       ? // When idle, we don't have a navigationValue on ArrowUp/Down
-        navigationValue || controlledValue || value
+      navigationValue || controlledValue || value
       : controlledValue || value;
 
   return (
@@ -462,9 +462,9 @@ export const ComboboxPopover = forwardRef(function ComboboxPopover(
 
   const popupProps = portal
     ? {
-        targetRef: inputRef,
-        position: positionMatchWidth
-      }
+      targetRef: inputRef,
+      position: positionMatchWidth
+    }
     : null;
 
   return (
@@ -594,17 +594,17 @@ export function ComboboxOptionText() {
 
   return results.length
     ? results.map((result, index) => {
-        const str = value.slice(result.start, result.end);
-        return (
-          <span
-            key={index}
-            data-user-value={result.highlight ? true : undefined}
-            data-suggested-value={result.highlight ? undefined : true}
-          >
-            {str}
-          </span>
-        );
-      })
+      const str = value.slice(result.start, result.end);
+      return (
+        <span
+          key={index}
+          data-user-value={result.highlight ? true : undefined}
+          data-suggested-value={result.highlight ? undefined : true}
+        >
+          {str}
+        </span>
+      );
+    })
     : value;
 }
 

--- a/packages/component-component/src/index.js
+++ b/packages/component-component/src/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { object, func, oneOfType, node } from "prop-types";
+import PropTypes from "prop-types";
 
 let cleanProps = props => {
   let {
@@ -20,7 +20,7 @@ let cleanProps = props => {
 
 class Component extends React.Component {
   static defaultProps = {
-    getInitialState: () => {},
+    getInitialState: () => { },
     getRefs: () => ({})
   };
 
@@ -99,24 +99,24 @@ class Component extends React.Component {
     return render
       ? render(this.getArgs())
       : typeof children === "function"
-      ? children(this.getArgs())
-      : children || null;
+        ? children(this.getArgs())
+        : children || null;
   }
 }
 
 if (__DEV__) {
   Component.propTypes = {
-    initialState: object,
-    getInitialState: func,
-    refs: object,
-    getRefs: func,
-    didMount: func,
-    didUpdate: func,
-    willUnmount: func,
-    getSnapshotBeforeUpdate: func,
-    shouldUpdate: func,
-    render: func,
-    children: oneOfType([func, node])
+    initialState: PropTypes.object,
+    getInitialState: PropTypes.func,
+    refs: PropTypes.object,
+    getRefs: PropTypes.func,
+    didMount: PropTypes.func,
+    didUpdate: PropTypes.func,
+    willUnmount: PropTypes.func,
+    getSnapshotBeforeUpdate: PropTypes.func,
+    shouldUpdate: PropTypes.func,
+    render: PropTypes.func,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node])
   };
 }
 

--- a/packages/dialog/src/index.js
+++ b/packages/dialog/src/index.js
@@ -3,9 +3,9 @@ import Portal from "@reach/portal";
 import { checkStyles, wrapEvent, useForkedRef } from "@reach/utils";
 import FocusLock from "react-focus-lock";
 import { RemoveScroll } from "react-remove-scroll";
-import { string, func, bool } from "prop-types";
+import PropTypes from "prop-types";
 
-const noop = () => {};
+const noop = () => { };
 
 ////////////////////////////////////////////////////////////////////////////////
 export const DialogOverlay = React.forwardRef(function DialogOverlay(
@@ -27,7 +27,7 @@ export const DialogOverlay = React.forwardRef(function DialogOverlay(
 
 if (__DEV__) {
   DialogOverlay.propTypes = {
-    initialFocusRef: () => {}
+    initialFocusRef: () => { }
   };
   DialogOverlay.displayName = "DialogOverlay";
 }
@@ -139,8 +139,8 @@ export const Dialog = React.forwardRef(function Dialog(
 
 if (__DEV__) {
   Dialog.propTypes = {
-    isOpen: bool,
-    onDismiss: func,
+    isOpen: PropTypes.bool,
+    onDismiss: PropTypes.func,
     "aria-label": ariaLabelType,
     "aria-labelledby": ariaLabelType
   };
@@ -202,12 +202,13 @@ function ariaLabelType(props, name, compName, ...rest) {
   if (props["aria-label"] && props["aria-labelledby"]) {
     return new Error(
       "You provided both `aria-label` and `aria-labelledby` props to a <" +
-        compName +
-        ">. If the a label for this component is visible on the screen, that label's component should be given a unique ID prop, and that ID should be passed as the `aria-labelledby` prop into <" +
-        compName +
-        ">. If the label cannot be determined programmatically from the content of the element, an alternative label should be provided as the `aria-label` prop, which will be used as an `aria-label` on the HTML tag." +
-        details
+      compName +
+      ">. If the a label for this component is visible on the screen, that label's component should be given a unique ID prop, and that ID should be passed as the `aria-labelledby` prop into <" +
+      compName +
+      ">. If the label cannot be determined programmatically from the content of the element, an alternative label should be provided as the `aria-label` prop, which will be used as an `aria-label` on the HTML tag." +
+      details
     );
   }
-  return string(name, props, compName, ...rest);
+  return PropTypes.string(name, props, compName, ...rest);
+
 }

--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -10,10 +10,10 @@ import React, {
 import Portal from "@reach/portal";
 import Rect, { useRect } from "@reach/rect";
 import Component from "@reach/component-component";
-import { node, func, object, string, number, oneOfType, any } from "prop-types";
+import PropTypes from "prop-types";
 import { wrapEvent, checkStyles, assignRef, useForkedRef } from "@reach/utils";
 
-const noop = () => {};
+const noop = () => { };
 let id = 0;
 const genId = () => `button-${++id}`;
 
@@ -115,7 +115,7 @@ export const Menu = ({ children }) => {
 
 if (__DEV__) {
   Menu.propTypes = {
-    children: oneOfType([func, node])
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node])
   };
   Menu.displayName = "Menu";
 }
@@ -175,9 +175,9 @@ export const MenuButton = forwardRef(function MenuButton(
 
 if (__DEV__) {
   MenuButton.propTypes = {
-    onClick: func,
-    onKeyDown: func,
-    children: node
+    onClick: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    children: PropTypes.node
   };
   MenuButton.displayName = "MenuButton";
 }
@@ -239,15 +239,15 @@ export const MenuItem = forwardRef(function MenuItem(
 
 if (__DEV__) {
   MenuItem.propTypes = {
-    onSelect: func.isRequired,
-    onClick: func,
-    role: string,
-    state: object,
-    setState: func,
-    onKeyDown: func,
-    onMouseMove: func,
-    _ref: func,
-    _index: number
+    onSelect: PropTypes.func.isRequired,
+    onClick: PropTypes.func,
+    role: PropTypes.string,
+    state: PropTypes.object,
+    setState: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    onMouseMove: PropTypes.func,
+    _ref: PropTypes.func,
+    _index: PropTypes.number
   };
   MenuItem.displayName = "MenuItem";
 }
@@ -301,12 +301,12 @@ export const MenuLink = forwardRef(function MenuLink(
 
 if (__DEV__) {
   MenuLink.propTypes = {
-    as: any,
-    component: any,
-    onClick: func,
-    onKeyDown: func,
-    _index: number,
-    _ref: func
+    as: PropTypes.any,
+    component: PropTypes.any,
+    onClick: PropTypes.func,
+    onKeyDown: PropTypes.func,
+    _index: PropTypes.number,
+    _ref: PropTypes.func
   };
   MenuLink.displayName = "MenuLink";
 }
@@ -346,7 +346,7 @@ export const MenuPopover = forwardRef(function MenuPopover(
 
 if (__DEV__) {
   MenuPopover.propTypes = {
-    children: node
+    children: PropTypes.node
   };
   MenuPopover.displayName = "MenuPopover";
 }
@@ -364,7 +364,7 @@ export const MenuList = forwardRef(function MenuList(props, forwardedRef) {
 
 if (__DEV__) {
   MenuList.propTypes = {
-    children: node.isRequired
+    children: PropTypes.node.isRequired
   };
   MenuList.displayName = "MenuList";
 }
@@ -446,12 +446,12 @@ export const MenuItems = forwardRef(function MenuItems(
 
 if (__DEV__) {
   MenuItems.propTypes = {
-    refs: object,
-    state: object,
-    setState: func,
-    children: node,
-    onKeyDown: func,
-    onBlur: func
+    refs: PropTypes.object,
+    state: PropTypes.object,
+    setState: PropTypes.func,
+    children: PropTypes.node,
+    onKeyDown: PropTypes.func,
+    onBlur: PropTypes.func
   };
   MenuItems.displayName = "MenuItems";
 }

--- a/packages/rect/src/index.js
+++ b/packages/rect/src/index.js
@@ -1,6 +1,6 @@
 import React, { useRef, useState, useLayoutEffect } from "react";
 import observeRect from "@reach/observe-rect";
-import { func, bool } from "prop-types";
+import PropTypes from "prop-types";
 
 let Rect = ({ onChange, observe, children }) => {
   const ref = React.useRef(null);
@@ -14,9 +14,9 @@ Rect.defaultProps = {
 
 if (__DEV__) {
   Rect.propTypes = {
-    children: func,
-    observe: bool,
-    onChange: func
+    children: PropTypes.func,
+    observe: PropTypes.bool,
+    onChange: PropTypes.func
   };
 }
 

--- a/packages/slider/src/index.js
+++ b/packages/slider/src/index.js
@@ -10,7 +10,7 @@ import React, {
   useRef,
   useState
 } from "react";
-import { node, func, number, string, bool, oneOf, oneOfType } from "prop-types";
+import PropTypes from "prop-types";
 import warning from "warning";
 import { useId } from "@reach/auto-id";
 import { wrapEvent, useForkedRef, makeId } from "@reach/utils";
@@ -45,23 +45,23 @@ const useSliderContext = () => useContext(SliderContext);
 // These proptypes are shared between the composed SliderInput component and the
 // simplified Slider
 const sliderPropTypes = {
-  defaultValue: number,
-  disabled: bool,
-  getValueText: func,
-  handleAlignment: oneOf([
+  defaultValue: PropTypes.number,
+  disabled: PropTypes.bool,
+  getValueText: PropTypes.func,
+  handleAlignment: PropTypes.oneOf([
     SLIDER_HANDLE_ALIGN_CENTER,
     SLIDER_HANDLE_ALIGN_CONTAIN
   ]),
-  min: number,
-  max: number,
-  name: string,
-  orientation: oneOf([
+  min: PropTypes.number,
+  max: PropTypes.number,
+  name: PropTypes.string,
+  orientation: PropTypes.oneOf([
     SLIDER_ORIENTATION_HORIZONTAL,
     SLIDER_ORIENTATION_VERTICAL
   ]),
-  onChange: func,
-  step: number,
-  value: number
+  onChange: PropTypes.func,
+  step: PropTypes.number,
+  value: PropTypes.number
 };
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -85,7 +85,7 @@ Slider.displayName = "Slider";
 if (__DEV__) {
   Slider.propTypes = {
     ...sliderPropTypes,
-    children: node
+    children: PropTypes.node
   };
 }
 
@@ -159,7 +159,7 @@ export const SliderInput = forwardRef(function SliderInput(
     handleAlignment === SLIDER_HANDLE_ALIGN_CENTER
       ? `${handleSize}px / 2`
       : `${handleSize}px * ${trackPercent * 0.01}`
-  })`;
+    })`;
 
   const updateValue = useCallback(
     function updateValue(newValue) {
@@ -197,7 +197,7 @@ export const SliderInput = forwardRef(function SliderInput(
     [isVertical, max, min, step]
   );
 
-  const handleKeyDown = wrapEvent(onKeyDown, function(event) {
+  const handleKeyDown = wrapEvent(onKeyDown, function (event) {
     let flag = false;
     let newValue;
     const tenSteps = (max - min) / 10;
@@ -244,7 +244,7 @@ export const SliderInput = forwardRef(function SliderInput(
     updateValue(newValue);
   });
 
-  const handlePointerDown = wrapEvent(onPointerDown, function(event) {
+  const handlePointerDown = wrapEvent(onPointerDown, function (event) {
     event.preventDefault();
     if (disabled) {
       if (isPointerDown) setPointerDown(false);
@@ -262,7 +262,7 @@ export const SliderInput = forwardRef(function SliderInput(
     }
   });
 
-  const handlePointerUp = wrapEvent(onPointerUp, function(event) {
+  const handlePointerUp = wrapEvent(onPointerUp, function (event) {
     if (sliderRef.current && event.pointerId) {
       sliderRef.current.releasePointerCapture &&
         sliderRef.current.releasePointerCapture(event.pointerId);
@@ -276,15 +276,15 @@ export const SliderInput = forwardRef(function SliderInput(
 
   const trackHighlightStyle = isVertical
     ? {
-        width: `100%`,
-        height: `${trackPercent}%`,
-        bottom: 0
-      }
+      width: `100%`,
+      height: `${trackPercent}%`,
+      bottom: 0
+    }
     : {
-        width: `${trackPercent}%`,
-        height: `100%`,
-        left: 0
-      };
+      width: `${trackPercent}%`,
+      height: `100%`,
+      left: 0
+    };
 
   const ctx = {
     ariaLabelledBy,
@@ -319,7 +319,7 @@ export const SliderInput = forwardRef(function SliderInput(
   });
 
   useEffect(() => {
-    const handlePointerMove = wrapEvent(onPointerMove, function(event) {
+    const handlePointerMove = wrapEvent(onPointerMove, function (event) {
       const newValue = getNewValueFromPointer(event);
       if (newValue !== value) {
         updateValue(newValue);
@@ -355,13 +355,13 @@ export const SliderInput = forwardRef(function SliderInput(
       >
         {typeof children === "function"
           ? children({
-              hasFocus,
-              id: sliderId,
-              max,
-              min,
-              value,
-              valueText
-            })
+            hasFocus,
+            id: sliderId,
+            max,
+            min,
+            value,
+            valueText
+          })
           : children}
         {name && (
           // If the slider is used in a form we'll need an input field to
@@ -385,7 +385,7 @@ SliderInput.displayName = "SliderInput";
 if (__DEV__) {
   SliderInput.propTypes = {
     ...sliderPropTypes,
-    children: oneOfType([node, func]).isRequired
+    children: PropTypes.oneOfType([PropTypes.node, PropTypes.func]).isRequired
   };
 }
 
@@ -420,7 +420,7 @@ SliderTrack.displayName = "SliderTrack";
 
 if (__DEV__) {
   SliderTrack.propTypes = {
-    children: node.isRequired
+    children: PropTypes.node.isRequired
   };
 }
 
@@ -572,7 +572,7 @@ SliderMarker.displayName = "SliderMarker";
 
 if (__DEV__) {
   SliderMarker.propTypes = {
-    value: number.isRequired
+    value: PropTypes.number.isRequired
   };
 }
 

--- a/packages/tabs/src/index.js
+++ b/packages/tabs/src/index.js
@@ -1,5 +1,5 @@
 import React, { cloneElement, useState, useRef, forwardRef } from "react";
-import { node, func, number } from "prop-types";
+import PropTypes from "prop-types";
 import warning from "warning";
 import { wrapEvent, useUpdateEffect, makeId, useForkedRef } from "@reach/utils";
 import { useId } from "@reach/auto-id";
@@ -51,14 +51,14 @@ export const Tabs = forwardRef(function Tabs(
       _onFocusPanel: () =>
         _selectedPanelRef.current && _selectedPanelRef.current.focus(),
       _onSelectTab: readOnly
-        ? () => {}
+        ? () => { }
         : index => {
-            _userInteractedRef.current = true;
-            onChange && onChange(index);
-            if (!isControlled) {
-              setSelectedIndex(index);
-            }
+          _userInteractedRef.current = true;
+          onChange && onChange(index);
+          if (!isControlled) {
+            setSelectedIndex(index);
           }
+        }
     });
   });
 
@@ -67,8 +67,8 @@ export const Tabs = forwardRef(function Tabs(
 
 if (__DEV__) {
   Tabs.propTypes = {
-    children: node.isRequired,
-    onChange: func,
+    children: PropTypes.node.isRequired,
+    onChange: PropTypes.func,
     index: (props, name, compName, ...rest) => {
       if (
         props.index > -1 &&
@@ -79,10 +79,10 @@ if (__DEV__) {
           "You provided a `value` prop to `Tabs` without an `onChange` handler. This will render a read-only tabs element. If the tabs should be mutable use `defaultIndex`. Otherwise, set `onChange`."
         );
       } else {
-        return number(name, props, compName, ...rest);
+        return PropTypes.number(name, props, compName, ...rest);
       }
     },
-    defaultIndex: number
+    defaultIndex: PropTypes.number
   };
 }
 
@@ -164,7 +164,7 @@ export const TabList = forwardRef(function TabList(
 
 if (__DEV__) {
   TabList.propTypes = {
-    children: node
+    children: PropTypes.node
   };
 }
 
@@ -207,7 +207,7 @@ export const Tab = forwardRef(function Tab(
 
 if (__DEV__) {
   Tab.propTypes = {
-    children: node
+    children: PropTypes.node
   };
 }
 
@@ -246,7 +246,7 @@ export const TabPanels = forwardRef(function TabPanels(
 
 if (__DEV__) {
   TabPanels.propTypes = {
-    children: node
+    children: PropTypes.node
   };
 }
 
@@ -275,6 +275,6 @@ export const TabPanel = forwardRef(function TabPanel(
 
 if (__DEV__) {
   TabPanel.propTypes = {
-    children: node
+    children: PropTypes.node
   };
 }

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -49,7 +49,7 @@ import { wrapEvent, checkStyles, useForkedRef, makeId } from "@reach/utils";
 import Portal from "@reach/portal";
 import VisuallyHidden from "@reach/visually-hidden";
 import { useRect } from "@reach/rect";
-import { node, string, func } from "prop-types";
+import PropTypes from "prop-types";
 
 ////////////////////////////////////////////////////////////////////////////////
 // ~The states~
@@ -243,8 +243,8 @@ export function useTooltip({
     DEBUG_STYLE
       ? true
       : id === null
-      ? false
-      : context.id === id && state === VISIBLE
+        ? false
+        : context.id === id && state === VISIBLE
   );
 
   // hopefully they always pass a ref if they ever pass one
@@ -393,9 +393,9 @@ function Tooltip({ children, label, ariaLabel, DEBUG_STYLE, ...rest }) {
 
 if (__DEV__) {
   Tooltip.propTypes = {
-    children: node.isRequired,
-    label: node.isRequired,
-    ariaLabel: string
+    children: PropTypes.node.isRequired,
+    label: PropTypes.node.isRequired,
+    ariaLabel: PropTypes.string
   };
   Tooltip.displayName = "Tooltip";
 }
@@ -436,9 +436,9 @@ export const TooltipPopup = forwardRef(function TooltipPopup(
 
 if (__DEV__) {
   TooltipPopup.propTypes = {
-    label: node.isRequired,
-    ariaLabel: string,
-    position: func
+    label: PropTypes.node.isRequired,
+    ariaLabel: PropTypes.string,
+    position: PropTypes.func
   };
   TooltipPopup.displayName = "TooltipPopup";
 }
@@ -518,12 +518,12 @@ const positionDefault = (triggerRect, tooltipRect) => {
       : `${triggerRect.left + window.pageXOffset}px`,
     top: directionUp
       ? `${triggerRect.top -
-          OFFSET -
-          tooltipRect.height +
-          window.pageYOffset}px`
+      OFFSET -
+      tooltipRect.height +
+      window.pageYOffset}px`
       : `${triggerRect.top +
-          OFFSET +
-          triggerRect.height +
-          window.pageYOffset}px`
+      OFFSET +
+      triggerRect.height +
+      window.pageYOffset}px`
   };
 };

--- a/packages/window-size/src/index.js
+++ b/packages/window-size/src/index.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { func } from "prop-types";
+import PropTypes from "prop-types";
 
 let hasWindow = typeof window !== "undefined";
 
@@ -10,7 +10,7 @@ export const WindowSize = ({ children }) => {
 
 if (__DEV__) {
   WindowSize.propTypes = {
-    children: func.isRequired
+    children: PropTypes.func.isRequired
   };
 }
 


### PR DESCRIPTION
This pull request:

- [X] Fixes a bug in an existing package

Fixes #375 

This PR fixes how the `prop-types` package is imported into various files. This project was attempting to destructure the import like: `import {node, func} from 'prop-types'` but the `prop-types` package does not export individual modules like that. This causes problems with bundlers like rollup. 

