### PR TITLE
tooltip: add document event listener to hide tooltip on escape

### DIFF
--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -270,13 +270,11 @@ export function useTooltip({
 
   useEffect(() => {
     const listener = event => {
-      if (event.key === "Escape" || event.key === "Esc") {
-        console.log("whoa");
-        switch (state) {
-          case VISIBLE: {
-            transition("selectWithKeyboard");
-          }
-        }
+      if (
+        (event.key === "Escape" || event.key === "Esc") &&
+        state === VISIBLE
+      ) {
+        transition("selectWithKeyboard");
       }
     };
     document.addEventListener("keydown", listener);

--- a/packages/tooltip/src/index.js
+++ b/packages/tooltip/src/index.js
@@ -268,6 +268,21 @@ export function useTooltip({
 
   useEffect(() => checkStyles("tooltip"));
 
+  useEffect(() => {
+    const listener = event => {
+      if (event.key === "Escape" || event.key === "Esc") {
+        console.log("whoa");
+        switch (state) {
+          case VISIBLE: {
+            transition("selectWithKeyboard");
+          }
+        }
+      }
+    };
+    document.addEventListener("keydown", listener);
+    return () => document.removeEventListener("keydown", listener);
+  }, []);
+
   const handleMouseEnter = () => {
     switch (state) {
       case IDLE:
@@ -331,7 +346,7 @@ export function useTooltip({
   };
 
   const handleKeyDown = event => {
-    if (event.key === "Enter" || event.key === " " || event.key === "Escape") {
+    if (event.key === "Enter" || event.key === " ") {
       switch (state) {
         case VISIBLE: {
           transition("selectWithKeyboard");


### PR DESCRIPTION
This PR addresses https://github.com/reach/reach-ui/issues/202. We move the event listener to the document so escaping at any point will dismiss the tooltip.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other