### PR TITLE
visually-hidden: Add guard for word wrapping

### DIFF
--- a/packages/visually-hidden/src/index.js
+++ b/packages/visually-hidden/src/index.js
@@ -1,7 +1,6 @@
 import React from "react";
 
 let style = {
-  display: "block",
   border: 0,
   clip: "rect(0 0 0 0)",
   height: "1px",
@@ -9,7 +8,11 @@ let style = {
   margin: "-1px",
   padding: 0,
   overflow: "hidden",
-  position: "absolute"
+  position: "absolute",
+
+  // https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe
+  whiteSpace: "nowrap",
+  wordWrap: "normal"
 };
 
 function VisuallyHidden(props) {


### PR DESCRIPTION
Added guards in `visually-hidden` to deal with potential issues related to word wrapping. Reference article here: https://medium.com/@jessebeach/beware-smushed-off-screen-accessible-text-5952a4c2cbfe

Went ahead and removed `display: block` since we're using `position: absolute` as well, per #372.