### PR TITLE
[combobox] Fix issue with Combobox context not being memoized correctly

### DIFF
--- a/packages/combobox/src/index.js
+++ b/packages/combobox/src/index.js
@@ -21,7 +21,12 @@ import React, {
   useState
 } from "react";
 import PropTypes from "prop-types";
-import { makeId, wrapEvent, useForkedRef } from "@reach/utils";
+import {
+  makeId,
+  wrapEvent,
+  useForkedRef,
+  useStableCallback
+} from "@reach/utils";
 import { findAll } from "highlight-words-core";
 import escapeRegexp from "escape-regexp";
 import { useId } from "@reach/auto-id";
@@ -810,7 +815,7 @@ function useReducerMachine(chart, reducer, initialData) {
   const [state, setState] = useState(chart.initial);
   const [data, dispatch] = useReducer(reducer, initialData);
 
-  const transition = (action, payload = {}) => {
+  const transition = useStableCallback((action, payload = {}) => {
     const currentState = chart.states[state];
     const nextState = currentState.on[action];
     if (!nextState) {
@@ -818,7 +823,7 @@ function useReducerMachine(chart, reducer, initialData) {
     }
     dispatch({ type: action, state, nextState: state, ...payload });
     setState(nextState);
-  };
+  });
 
   return [state, data, transition];
 }

--- a/packages/utils/index.d.ts
+++ b/packages/utils/index.d.ts
@@ -55,6 +55,16 @@ export function usePrevious<T>(value: T): T;
 export function useUpdateEffect(effect: () => any, deps?: any[]): void;
 
 /**
+ * Returns a stable reference to an input callback
+ * which changes its reference throughout component's lifetime.
+ *
+ * @param callback A function for which we want to create a stable reference.
+ */
+export function useStableCallback<T extends (...args: any[]) => any>(
+  callback: T
+): T;
+
+/**
  * Wraps a lib-defined event handler and a user-defined event handler,
  * returning a single handler that allows a user to prevent lib-defined
  * handlers from firing.

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,5 +19,8 @@
     "lib",
     "index.js",
     "index.d.ts"
-  ]
+  ],
+  "dependencies": {
+    "use-latest": "^1.0.0"
+  }
 }

--- a/packages/utils/src/index.js
+++ b/packages/utils/src/index.js
@@ -1,4 +1,5 @@
-import { useRef, useMemo, useEffect } from "react";
+import { useRef, useMemo, useEffect, useCallback } from "react";
+import useLatest from "use-latest";
 
 let checkedPkgs = {};
 
@@ -94,6 +95,11 @@ export function useUpdateEffect(effect, deps) {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, deps);
+}
+
+export function useStableCallback(callback) {
+  const latestRef = useLatest(callback);
+  return useCallback((...args) => latestRef.current(...args), [latestRef]);
 }
 
 export function wrapEvent(theirHandler, ourHandler) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3032,7 +3032,7 @@
     "@types/history" "*"
     "@types/react" "*"
 
-"@types/react-dom@*", "@types/react-dom@16.9.4", "@types/react-dom@^16.9.4":
+"@types/react-dom@*", "@types/react-dom@^16.9.4":
   version "16.9.4"
   resolved "https://registry.yarnpkg.com/@types/react-dom/-/react-dom-16.9.4.tgz#0b58df09a60961dcb77f62d4f1832427513420df"
   integrity sha512-fya9xteU/n90tda0s+FtN5Ym4tbgxpq/hb/Af24dvs6uYnYn+fspaxw5USlw0R8apDNwxsqumdRoCoKitckQqw==
@@ -3053,7 +3053,7 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@16.9.11", "@types/react@^16.9.11":
+"@types/react@*", "@types/react@^16.9.11":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"
   integrity sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==
@@ -12744,6 +12744,11 @@ use-callback-ref@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.2.1.tgz#898759ccb9e14be6c7a860abafa3ffbd826c89bb"
   integrity sha512-C3nvxh0ZpaOxs9RCnWwAJ+7bJPwQI8LHF71LzbQ3BvzH5XkdtlkMadqElGevg5bYBDFip4sAnD4m06zAKebg1w==
+
+use-latest@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/use-latest/-/use-latest-1.0.0.tgz#c86d2e4893b15f27def69da574a47136d107facb"
+  integrity sha512-CxmFi75KTXeTIBlZq3LhJ4Hz98pCaRKZHCpnbiaEHIr5QnuHvH8lKYoluPBt/ik7j/hFVPB8K3WqF6mQvLyQTg==
 
 use-sidecar@^1.0.1:
   version "1.0.2"


### PR DESCRIPTION
This pull request:
- [x] Fixes a bug in an existing package

When trying to reproduce a problem described in https://github.com/reach/reach-ui/issues/199 I've noticed that it currently cannot be reproduced because:
- [`transition`](https://github.com/reach/reach-ui/blob/f22cdf931d52384205575f3060933241056e4d1e/packages/combobox/src/index.js#L813) is an inline function, so it has a fresh reference for each render
- but it's used as input for `useMemo` [here](https://github.com/reach/reach-ui/blob/f22cdf931d52384205575f3060933241056e4d1e/packages/combobox/src/index.js#L282), which makes `useMemo` yield a new reference each render and thus constantly updating the context value

I've fixed it by creating a "proxy" callback to this inline one. This way that "proxy" can have a stable reference across renders but still call "latest" version of the inline function thanks to using a ref under the hood.

I believe this solution is better than using `useCallback` directly because I think that `transition`'s reference shouldn't ever update, it should be considered stable - similarly how we can assume `setState` & `dispatch` to be stable.

