### PR TITLE
[all] Add repository infos to packages manifest

### DIFF
--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/alert-dialog",
   "version": "0.6.1",
   "description": "Accessible React Alert Dialog.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/alert-dialog"
+  },
   "author": "React Training <hello@reacttraining.com>",
   "license": "MIT",
   "main": "index.js",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/alert",
   "version": "0.6.1",
   "description": "Screenreader friendly alert messages.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/alert"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/auto-id/package.json
+++ b/packages/auto-id/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/auto-id",
   "version": "0.6.1",
   "description": "Autogenerate IDs to facilitate WAI-ARIA and server rendering.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/auto-id"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/combobox",
   "version": "0.6.1",
   "description": "Accessible React Combobox (Autocomplete).",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/combobox"
+  },
   "author": "React Training <hello@reacttraining.com>",
   "license": "MIT",
   "main": "index.js",

--- a/packages/component-component/package.json
+++ b/packages/component-component/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/component-component",
   "version": "0.6.1",
   "description": "Declarative React Component Definitions",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/component-component"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/dialog",
   "version": "0.6.1",
   "description": "Accessible React Modal Dialog.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/dialog"
+  },
   "author": "React Training <hello@reacttraining.com>",
   "license": "MIT",
   "main": "index.js",

--- a/packages/menu-button/package.json
+++ b/packages/menu-button/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/menu-button",
   "version": "0.6.1",
   "description": "Accessible React button dropdown menu.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/menu-button"
+  },
   "author": "React Training <hello@reacttraining.com>",
   "license": "MIT",
   "main": "index.js",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/popover",
   "version": "0.6.1",
   "description": "Render a portal positioned relative to another element.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/popover"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/portal",
   "version": "0.6.1",
   "description": "Declarative portals for React",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/portal"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/rect/package.json
+++ b/packages/rect/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/rect",
   "version": "0.6.1",
   "description": "Measure React elements position in the DOM",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/rect"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/skip-nav/package.json
+++ b/packages/skip-nav/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/skip-nav",
   "version": "0.6.1",
   "description": "Skip navigation links for screen reader and keyboard users.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/skip-nav"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/slider",
   "version": "0.6.1",
   "description": "Accessible React Slider Component",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/slider"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/tabs",
   "version": "0.6.1",
   "description": "Accessible React Tabs Component",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/tabs"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -7,6 +7,11 @@
   "scripts": {
     "build": "node ../../shared/build-package"
   },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/tooltip"
+  },
   "dependencies": {
     "@reach/auto-id": "^0.6.1",
     "@reach/portal": "^0.6.1",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/utils",
   "version": "0.6.1",
   "description": "Internal, shared utilities for Reach UI.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/utils"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/visually-hidden",
   "version": "0.6.1",
   "description": "Render text that is announced to screen readers but visually hidden.",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/visually-hidden"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {

--- a/packages/window-size/package.json
+++ b/packages/window-size/package.json
@@ -2,6 +2,11 @@
   "name": "@reach/window-size",
   "version": "0.6.1",
   "description": "Measure the window size in React",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/reach/reach-ui.git",
+    "directory": "packages/window-size"
+  },
   "main": "index.js",
   "module": "es/index.js",
   "scripts": {


### PR DESCRIPTION
It will add repo link on NPM and allow bots to get more informations about that packages (i.e. dependabot, renovate...)

When using dependabot, it will correctly find the packages repository and add link with a list of commits/releases inside the dependabot PR. 
Currently, we just have a text with the name of the packages to be updated:
<img width="756" alt="Screenshot 2019-11-20 at 11 16 01" src="https://user-images.githubusercontent.com/10224453/69230239-2b1c8000-0b87-11ea-8a65-e38638a3b755.png">
