### PR TITLE
[Tooltip] Make `ref` optional on `useTooltip` hook types

### DIFF
--- a/packages/tooltip/index.d.ts
+++ b/packages/tooltip/index.d.ts
@@ -30,7 +30,7 @@ export interface TooltipParams {
 
 export function useTooltip<T = any>(
   attrs?: {
-    ref: React.Ref<T>;
+    ref?: React.Ref<T>;
     DEBUG_STYLE?: boolean;
   } & React.HTMLProps<T>
 ): [TriggerParams, TooltipParams, boolean];


### PR DESCRIPTION
Currently `ref` is required when calling the `useTooltip` hook. This shouldn't be the case, since `useTooltip` has its own internal ref, if not provided.

Related error:

![image](https://user-images.githubusercontent.com/23662329/69326249-24a80a00-0c54-11ea-8b7a-dfb07cfc502d.png)
