### PR TITLE
[MenuButton] Ensure MenuPopover's collisions.bottom takes into account the button's height

### DIFF
--- a/packages/menu-button/src/index.js
+++ b/packages/menu-button/src/index.js
@@ -532,7 +532,8 @@ function getStyles(buttonRect, menuRect) {
   const collisions = {
     top: buttonRect.top - menuRect.height < 0,
     right: window.innerWidth < buttonRect.left + menuRect.width,
-    bottom: window.innerHeight < buttonRect.top + menuRect.height,
+    bottom:
+      window.innerHeight < buttonRect.top + buttonRect.height + menuRect.height,
     left: buttonRect.left + buttonRect.width - menuRect.width < 0
   };
 


### PR DESCRIPTION
This pull request:

- [x] Fixes a bug in an existing package

---

This fixes a bug in MenuButton's MenuPopover where the menu is placed under the button, but the math for detecting whether it would collide with the bottom of the viewport doesn't take into account the button's height. 

This means the menu list will extend past the bottom of the page by as much as the menu button's height without detecting a collision.