### PR TITLE
docs(alert-dialog): Fix mismatched closing tag in example

### DIFF
--- a/website/src/pages/alert-dialog.mdx
+++ b/website/src/pages/alert-dialog.mdx
@@ -252,7 +252,7 @@ Accepts any renderable content but should generally be restricted to `AlertDialo
 <AlertDialog>
   <AlertDialogLabel>
     Please Confirm!
-  </AlertDialog>
+  </AlertDialogLabel>
 
   <AlertDialogDescription>
     A longer message


### PR DESCRIPTION
Fixes a mismatched closing tag in the docs for `<AlertDialog />`.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other
