### PR TITLE
Remove unused styled-components dependency from menu-button typescript definitions

### DIFF
--- a/packages/menu-button/index.d.ts
+++ b/packages/menu-button/index.d.ts
@@ -8,7 +8,6 @@
  */
 
 import * as React from "react";
-import { StyledComponent } from "styled-components";
 
 type ResolvedMenuItemComponent<T> = T extends keyof JSX.IntrinsicElements
   ? T


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [x] Fixes a bug in an existing package

---

**tl;dr**: Removes an unused import which prevents typescript compilation in non-styled-components environments.


This PR removed an unused import from `menu-button`'s TypeScript definitions introduced in 18281e8. The import value is unused, and the existence of the import means type checking any project with `@reach-ui/menu-button` `0.6.3` without `@types/styled-components` also installed will fail with this error:

```
node_modules/@reach/menu-button/index.d.ts:11:33 - error TS2307: Cannot find module 'styled-components'.
| import { StyledComponent } from "styled-components";
```

In general we should avoid depending on `styled-components` types specifically as it prevents the use of other popular CSS-in-JS packages such as [emotion](https://github.com/emotion-js/emotion) or CSS Modules-type approaches; but more immediately the import removed in this PR allows TypeScript to compile again for consumers not using `styled-components`