### PR TITLE
[menu-button] Use React.ButtonHTMLAttributes for types

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -214,7 +214,7 @@ export const MenuButton = forwardRef<HTMLButtonElement, MenuButtonProps>(
 /**
  * @see Docs https://reacttraining.com/reach-ui/menu-button#menubutton-props
  */
-export type MenuButtonProps = React.HTMLAttributes<HTMLButtonElement> & {
+export type MenuButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
   /**
    * Accepts any renderable content.
    *


### PR DESCRIPTION
Right now, when using `disabled` (a valid HTML attribute) on `MenuButton`, would error in TypeScript as:

```
Property 'disabled' does not exist on type 'IntrinsicAttributes & HTMLAttributes<HTMLButtonElement> & { children: ReactNode; } & RefAttributes<HTMLButtonElement>'.

<MenuButton className={styles.select} disabled={disabled} onClick={onOpen} {...rest}>
```