### PR TITLE
[Utils] Remove the mandatory of "as" type

### DIFF
--- a/packages/utils/src/types.tsx
+++ b/packages/utils/src/types.tsx
@@ -30,7 +30,7 @@ export type ComponentWithForwardedRef<
 >;
 
 export interface ComponentWithAs<T extends As, P> {
-  <TT extends As>(props: PropsWithAs<TT, P> & { as: TT }): JSX.Element;
+  <TT extends As>(props: PropsWithAs<TT, P>): JSX.Element;
   (props: PropsWithAs<T, P>): JSX.Element;
   displayName?: string;
   propTypes?: {


### PR DESCRIPTION
This PR removes `as` as mandatory prop of components that wrapped with `ComponentWithAs` 
fixes #427 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [X] Add or edit tests to reflect the change (Run with `yarn test`).
- [X] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [X] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other