### PR TITLE
Allow passing in an optional name prop for <Combobox />

### DIFF
--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -402,6 +402,7 @@ export const ComboboxInput = forwardRefWithAs<"div", ComboboxInputProps>(
       onBlur,
       onFocus,
       value: controlledValue,
+      name,
       ...props
     },
     forwardedRef
@@ -489,6 +490,7 @@ export const ComboboxInput = forwardRefWithAs<"div", ComboboxInputProps>(
         {...props}
         data-reach-combobox-input=""
         ref={ref}
+        name={name}
         value={inputValue || ""}
         onClick={wrapEvent(onClick, handleClick)}
         onBlur={wrapEvent(onBlur, handleBlur)}
@@ -538,6 +540,10 @@ export type ComboboxInputProps = {
    * @see Docs https://reacttraining.com/reach-ui/combobox#comboboxinput-value
    */
   value?: ComboboxValue;
+  /**
+   * The name attribute of the internal <input /> element.
+   */
+  name?: string;
 };
 
 ComboboxInput.displayName = "ComboboxInput";


### PR DESCRIPTION
I am using [react-hook-form](https://react-hook-form.com/) as my form library. This form library expects a way to pass a`ref` in which `ComboboxInput` already provides. Additionally, it also expects that the internal DOM element has a `name` prop defined which `ComboInput` doesn't have.

Hence, this PR allows an optional `name` prop that gets passed to the underlying `<input />` tag.


- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.js` entry file
  - [ ] Type definitions in an `index.d.ts` file are desired but not required for the PR to be merged
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
