### PR TITLE
[Several Packages] Remove several type casts

### DIFF
--- a/packages/alert-dialog/src/index.tsx
+++ b/packages/alert-dialog/src/index.tsx
@@ -78,7 +78,7 @@ export const AlertDialogOverlay = forwardRef<HTMLDivElement, AlertDialogProps>(
       >
         <DialogOverlay
           {...props}
-          ref={forwardRef as any}
+          ref={forwardRef}
           data-reach-alert-dialog-overlay
           initialFocusRef={leastDestructiveRef}
         />
@@ -138,7 +138,7 @@ export const AlertDialogContent = forwardRef<
       role="alertdialog"
       aria-labelledby={labelId}
       {...props}
-      ref={forwardRef as any}
+      ref={forwardRef}
       // lol: remove in 1.0
       data-reach-alert-dialong-content
       data-reach-alert-dialog-content

--- a/packages/alert-dialog/src/index.tsx
+++ b/packages/alert-dialog/src/index.tsx
@@ -92,7 +92,7 @@ if (__DEV__) {
   AlertDialogOverlay.propTypes = {
     isOpen: PropTypes.bool,
     onDismiss: PropTypes.func,
-    leastDestructiveRef: (() => {}) as any,
+    leastDestructiveRef: () => null,
     children: PropTypes.node
   };
 }
@@ -278,7 +278,7 @@ if (__DEV__) {
   AlertDialog.propTypes = {
     isOpen: PropTypes.bool,
     onDismiss: PropTypes.func,
-    leastDestructiveRef: (() => {}) as any,
+    leastDestructiveRef: () => null,
     children: PropTypes.node
   };
 }

--- a/packages/alert/src/index.tsx
+++ b/packages/alert/src/index.tsx
@@ -146,12 +146,12 @@ function renderAlerts() {
               role={type === "assertive" ? "alert" : "status"}
               aria-live={type}
             >
-              {Object.keys(elements[type]).map(key => {
+              {Object.keys(elements[type]).map(key =>
                 React.cloneElement(elements[type][key], {
                   key,
                   ref: null
-                });
-              })}
+                })
+              )}
             </div>
           </VisuallyHidden>,
           liveRegions[type]

--- a/packages/alert/src/index.tsx
+++ b/packages/alert/src/index.tsx
@@ -146,12 +146,12 @@ function renderAlerts() {
               role={type === "assertive" ? "alert" : "status"}
               aria-live={type}
             >
-              {Object.keys(elements[type]).map(key =>
-                React.cloneElement(elements[type][key as any], {
+              {Object.keys(elements[type]).map(key => {
+                React.cloneElement(elements[type][key], {
                   key,
                   ref: null
-                })
-              )}
+                });
+              })}
             </div>
           </VisuallyHidden>,
           liveRegions[type]
@@ -205,7 +205,7 @@ type RegionTypes = "polite" | "assertive";
 
 type ElementTypes = {
   [key in RegionTypes]: {
-    [key: number]: JSX.Element;
+    [key: string]: JSX.Element;
   };
 };
 

--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -18,7 +18,7 @@ import { RemoveScroll } from "react-remove-scroll";
 import PropTypes from "prop-types";
 
 const overlayPropTypes = {
-  initialFocusRef: (() => {}) as any,
+  initialFocusRef: () => null,
   allowPinchZoom: PropTypes.bool,
   onDismiss: PropTypes.func
 };

--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -923,12 +923,7 @@ type MenuButtonAction =
   | { type: "SEARCH_FOR_ITEM"; payload: string };
 
 function isRightClick(nativeEvent: MouseEvent) {
-  if ("which" in nativeEvent) {
-    return nativeEvent.which === 3;
-  } else if ("button" in nativeEvent) {
-    return (nativeEvent as any).button === 2;
-  }
-  return false;
+  return nativeEvent.which === 3 || nativeEvent.button === 2;
 }
 
 function reducer(

--- a/packages/tabs/src/index.tsx
+++ b/packages/tabs/src/index.tsx
@@ -613,15 +613,19 @@ if (__DEV__) {
   };
 }
 
+type HTMLElementWithCurrentStyle = HTMLElement & {
+  currentStyle?: Record<string, string>;
+};
+
 /**
  * Get a computed style value by property, backwards compatible with IE
  * @param element
  * @param styleProp
  */
-function getStyle(element: HTMLElement, styleProp: string) {
+function getStyle(element: HTMLElementWithCurrentStyle, styleProp: string) {
   let y: string | null = null;
-  if ((element as any).currentStyle) {
-    y = (element as any).currentStyle[styleProp] as string;
+  if (element.currentStyle) {
+    y = element.currentStyle[styleProp];
   } else if (
     element.ownerDocument &&
     element.ownerDocument.defaultView &&

--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -246,7 +246,7 @@ export function useTooltip<T extends HTMLElement>({
   // hopefully they always pass a ref if they ever pass one
   const ownRef = useRef<HTMLDivElement | null>(null);
 
-  const ref = useForkedRef(forwardedRef as any, ownRef); // TODO: Fix in utils
+  const ref = useForkedRef(forwardedRef, ownRef);
   const triggerRect = useRect(ownRef, isVisible);
 
   useEffect(() => {

--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -319,7 +319,7 @@ export function useTooltip<T extends HTMLElement>({
     "aria-describedby": isVisible ? makeId("tooltip", id) : undefined,
     "data-reach-tooltip-trigger": "",
     ref,
-    onMouseEnter: wrapEvent(onMouseEnter as any, handleMouseEnter),
+    onMouseEnter: wrapEvent(onMouseEnter, handleMouseEnter),
     onMouseMove: wrapEvent(onMouseMove, handleMouseMove),
     onFocus: wrapEvent(onFocus, handleFocus),
     onBlur: wrapEvent(onBlur, handleBlur),

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -72,7 +72,10 @@ export { checkStyles };
  * @param ref
  * @param value
  */
-export function assignRef<T = any>(ref: AssignableRef<T>, value: any) {
+export function assignRef<T = any>(
+  ref: AssignableRef<T> | undefined,
+  value: any
+) {
   if (ref == null) return;
   if (typeof ref === "function") {
     ref(value);
@@ -174,7 +177,9 @@ export function noop(): void {}
  *
  * @param refs Refs to fork
  */
-export function useForkedRef<T = any>(...refs: AssignableRef<T>[]) {
+export function useForkedRef<T = any>(
+  ...refs: (AssignableRef<T> | undefined)[]
+) {
   return useMemo(() => {
     if (refs.every(ref => ref == null)) {
       return null;
@@ -265,7 +270,7 @@ export function wrapEvent<E extends React.SyntheticEvent | Event>(
 /**
  * This is a hack for sure. The thing is, getting a component to intelligently
  * infer props based on a component or JSX string passed into an `as` prop is
- * kind of a huge pain. Getting it to work and satisfy the contraints of
+ * kind of a huge pain. Getting it to work and satisfy the constraints of
  * `forwardRef` seems dang near impossible. To avoid needing to do this awkward
  * type song-and-dance every time we want to forward a ref into a component
  * that accepts an `as` prop, we abstract all of that mess to this function for


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other (types)

The inspiration for these changes [was this tweet](https://twitter.com/chancethedev/status/1218399362746933248) 😅. I didn't see any contributing guidelines _(I could've missed them)_ so I wasn't confident if it was necessary to do a PR per package? If that's the case, I'm happy to separate out these changes!

I searched for `as any` in the codebase and attempted to resolve most of the more straightforward ones. There are a few more but those will likely be much more involved. 

There were a few types of changes:

- Converted the prop types `() => {}` to `() => null` to comply with their type definitions. [They expect either `Error` or `null`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/d459d36f4e1f47c3c6273b287718c79426e41a9f/types/prop-types/index.d.ts#L41).
- Converted the `ElementTypes`'s `RegionTypes`'s value to have a index signature of a `string`. This allowed removing the type case of `key as any` and to complies with `Object.keys`: ["An array of strings that represent all the enumerable properties of the given object."](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#Syntax).
```js
// array like object
const obj = { 0: 'a', 1: 'b', 2: 'c' };
console.log(Object.keys(obj)); // console: ['0', '1', '2']
```
- Simplified `isRightClick`. Previously the statement `"which" in nativeEvent` was evaluated as always true so the second `else if` was always `never`. If accessing one of these fields and it doesn't exist it should be `undefined` and since this was using triple equals we should be safe against something like `0 == undefined`.  So it should be safe to remove the check before accessing the fields? I'm happy to revert if this is an unsafe change. I verified with logic like this: 
```js
const ev = new MouseEvent("myDummyTest")
ev.which === 1 || ev.button === 1 // true
ev.wat === 1 || ev.idk === 1 // false
```
- Since it appears `currentStyle` was used very intentionally for IE support ([assuming from the MDN docs](https://developer.mozilla.org/en-US/docs/Web/API/Element/currentStyle)) I added a type `HTMLElementWithCurrentStyle` to allow accessing that attribute since it will probably never get added to the TS libraries.
- Allowed `useForkedRef` to accept `undefined` because it should safely handle in `assignRef` with the _double_ equality check of `if (ref == null) return;`.
- Fixed unrelated typo