### PR TITLE
Allow passing the style property to MenuPopover again.

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -812,7 +812,7 @@ if (__DEV__) {
  * @see Docs https://reacttraining.com/reach-ui/menu-button#menupopover
  */
 export const MenuPopover = forwardRef<any, MenuPopoverProps>(
-  function MenuPopover({ children, onBlur, style, ...props }, forwardedRef) {
+  function MenuPopover({ children, onBlur, ...props }, forwardedRef) {
     const {
       buttonRef,
       dispatch,


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

Since https://github.com/reach/reach-ui/commit/7407794c58fac136ba67c5f009782d30c2f9020d  it is disallowed to pass the style property to the `<MenuPopover />` component in the `@reach/menu-button` package. I couldn't figure out any specific reason for this change.