### PR TITLE
[alert] Fix spread typing

### DIFF
--- a/packages/alert/src/index.tsx
+++ b/packages/alert/src/index.tsx
@@ -88,7 +88,7 @@ export type AlertProps = {
    */
   type?: "assertive" | "polite";
   children: React.ReactNode;
-};
+} & React.HTMLAttributes<HTMLDivElement>;
 
 Alert.displayName = "Alert";
 if (__DEV__) {


### PR DESCRIPTION
Using Typescript we wasn't able to pass props to the `Alert` component to be spread into the nested div (useful for style, className, ...).

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`) __I can't get it working on my computer, but not related to this PR (`ModuleNotFoundError: Module not found: Error: Can't resolve '@storybook/addon-info/register' in 'Dev/Projects/reach-ui'`). I tried `yarn --force`, no changes.__
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [x] Fixes a bug in an existing package