### PR TITLE
docs(rect): update first render return value

### DIFF
--- a/website/src/pages/rect.mdx
+++ b/website/src/pages/rect.mdx
@@ -88,7 +88,7 @@ _Type_: `func: ({ ref, rect }) => node`
 
 A function that calls back to you with a `ref` to place on an element and the `rect` measurements of the dom node.
 
-**Note**: On the first render `rect` will be `undefined` because we can't measure a node that has not yet been rendered. Make sure your code accounts for this.
+**Note**: On the first render `rect` will be `null` because we can't measure a node that has not yet been rendered. Make sure your code accounts for this.
 
 ##### Rect observe
 


### PR DESCRIPTION
[`useRect` returns `null`](https://github.com/reach/reach-ui/blob/master/packages/rect/src/index.tsx#L94) rather than `undefined` on the first render.  I suppose a library consumer could get tripped up assuming it was `undefined` and write something like `if (typeof rect === 'object') rect.width` which would throw an error when `rect` is `null`.



Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.js` entry file
  - [ ] Type definitions in an `index.d.ts` file are desired but not required for the PR to be merged
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
