### PR TITLE
[Menu-Button] Fix double-invoking onSelect in StrictMode

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -324,10 +324,13 @@ const MenuItemImpl = forwardRefWithAs<MenuItemImplProps, "div">(
     let isSelected = index === selectionIndex;
 
     function select() {
-      dispatch({
-        type: CLICK_MENU_ITEM,
-        payload: { buttonRef, callback: onSelect },
-      });
+      /*
+       * Focus the button first by default when an item is selected. We fire the
+       * onSelect callback next so the app can manage focus if needed.
+       */
+      focus(buttonRef.current);
+      onSelect && onSelect();
+      dispatch({ type: CLICK_MENU_ITEM });
     }
 
     function handleClick(event: React.MouseEvent) {
@@ -915,10 +918,7 @@ interface MenuButtonState {
 }
 
 type MenuButtonAction =
-  | {
-      type: "CLICK_MENU_ITEM";
-      payload: { buttonRef: ButtonRef; callback?: () => any };
-    }
+  | { type: "CLICK_MENU_ITEM" }
   | { type: "CLOSE_MENU"; payload: { buttonRef: ButtonRef } }
   | { type: "OPEN_MENU_AT_FIRST_ITEM" }
   | {
@@ -947,12 +947,6 @@ function reducer(
 ): MenuButtonState {
   switch (action.type) {
     case CLICK_MENU_ITEM:
-      /*
-       * Focus the button first by default when an item is selected. We fire the
-       * onSelect callback next so the app can manage focus if needed.
-       */
-      focus(action.payload.buttonRef.current);
-      action.payload.callback && action.payload.callback();
       return {
         ...state,
         isOpen: false,


### PR DESCRIPTION
Render phase work like useReducer functions can be called more than once in concurrent mode which makes them unsuitable for performing side effects. [Strict Mode](https://reactjs.org/docs/strict-mode.html#detecting-unexpected-side-effects) always double invokes them to help catch these issues.

This PR should fix #440 by moving the focus and callback calls into the event handler, which does not get double invoked in concurrent / StrictMode.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)