### PR TITLE
[Combobox] Use ARIA 1.2 spec

### DIFF
--- a/packages/combobox/__tests__/__snapshots__/combobox.test.tsx.snap
+++ b/packages/combobox/__tests__/__snapshots__/combobox.test.tsx.snap
@@ -8,19 +8,18 @@ exports[`<Combobox /> should match the snapshot: after text input 1`] = `
         Clientside Search
       </h2>
       <div
-        aria-expanded="true"
-        aria-haspopup="listbox"
-        aria-owns="listbox--holy-smokes"
         data-reach-combobox=""
         id="holy-smokes"
-        role="combobox"
       >
         <input
           aria-autocomplete="both"
           aria-controls="listbox--holy-smokes"
+          aria-expanded="true"
+          aria-haspopup="listbox"
           data-reach-combobox-input=""
           data-testid="input"
           name="awesome"
+          role="combobox"
           value="e"
         />
         <div
@@ -379,19 +378,18 @@ exports[`<Combobox /> should match the snapshot: before text input 1`] = `
         Clientside Search
       </h2>
       <div
-        aria-expanded="false"
-        aria-haspopup="listbox"
-        aria-owns="listbox--holy-smokes"
         data-reach-combobox=""
         id="holy-smokes"
-        role="combobox"
       >
         <input
           aria-autocomplete="both"
           aria-controls="listbox--holy-smokes"
+          aria-expanded="false"
+          aria-haspopup="listbox"
           data-reach-combobox-input=""
           data-testid="input"
           name="awesome"
+          role="combobox"
           value=""
         />
         <span>

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -332,15 +332,7 @@ export const Combobox = forwardRefWithAs<ComboboxProps, "div">(
         set={setOptions}
       >
         <ComboboxContext.Provider value={context}>
-          <Comp
-            aria-haspopup="listbox"
-            aria-owns={listboxId}
-            aria-expanded={context.isVisible}
-            role="combobox"
-            {...rest}
-            data-reach-combobox=""
-            ref={forwardedRef}
-          >
+          <Comp {...rest} data-reach-combobox="" ref={forwardedRef}>
             {children}
           </Comp>
         </ComboboxContext.Provider>
@@ -421,6 +413,7 @@ export const ComboboxInput = forwardRefWithAs<ComboboxInputProps, "input">(
       listboxId,
       autocompletePropRef,
       openOnFocus,
+      isVisible,
     } = useContext(ComboboxContext);
 
     let ref = useForkedRef(inputRef, forwardedRef);
@@ -515,6 +508,9 @@ export const ComboboxInput = forwardRefWithAs<ComboboxInputProps, "input">(
         }
         aria-autocomplete="both"
         aria-controls={listboxId}
+        aria-expanded={isVisible}
+        aria-haspopup="listbox"
+        role="combobox"
         {...props}
         data-reach-combobox-input=""
         ref={ref}


### PR DESCRIPTION
## Summary

[Use ARIA 1.2 spec for combobox][4]

The [ARIA 1.1 spec for combobox][6] (used in Reach right now … kind of *) was meant to solve a structural pitfall of ARIA 1.0, but ended up introducing a whole set of [new problems][1] in the wake. The 1.1 implementation is quite broken for VoiceOver.

In a study done in 12/2019, [ARIA 1.2 is less buggy across board compared to ARIA 1.1][2]. The author of this study, Sarah Higley, is on the accessibility working group within the W3C, and after a colleague spoke with her recently (cc: @backwardok) she recommended moving forward with the 1.2 spec given its better effective support by browsers and screen readers.

\* Reach currently mixes ARIA 1.1 and ARIA 1.2, given that it [includes `aria-controls` on the input itself][5]—despite that not being part of the 1.1 spec—but includes the rest of the aria on the container.

[1]: https://github.com/w3c/aria/wiki/Resolving-ARIA-1.1-Combobox-Issues#aria-11-problems
[2]: https://www.24a11y.com/2019/select-your-poison-part-2/
[4]: https://github.com/reach/reach-ui/pull/479/files?file-filters%5B%5D=.tsx#diff-4ca2b9f6476e4d552f6572d4059cff55
[5]: https://github.com/reach/reach-ui/blob/6aff35f77ac18b27d0539793e4062aebc14f2fdc/packages/combobox/src/index.tsx#L508
[6]: https://www.w3.org/TR/wai-aria-practices-1.1/#combobox

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
