### PR TITLE
Add positionRight helper to Popover

### DIFF
--- a/packages/popover/src/index.tsx
+++ b/packages/popover/src/index.tsx
@@ -89,22 +89,40 @@ function getStyles(
   return position(targetRect, popoverRect);
 }
 
+function getTopPosition(targetRect: PRect, popoverRect: PRect) {
+  const { directionUp } = getCollisions(targetRect, popoverRect);
+  return {
+    top: directionUp
+      ? `${targetRect.top - popoverRect.height + window.pageYOffset}px`
+      : `${targetRect.top + targetRect.height + window.pageYOffset}px`,
+  };
+}
+
 export const positionDefault: Position = (targetRect, popoverRect) => {
   if (!targetRect || !popoverRect) {
     return {};
   }
 
-  const { directionUp, directionRight } = getCollisions(
-    targetRect,
-    popoverRect
-  );
+  const { directionRight } = getCollisions(targetRect, popoverRect);
   return {
     left: directionRight
       ? `${targetRect.right - popoverRect.width + window.pageXOffset}px`
       : `${targetRect.left + window.pageXOffset}px`,
-    top: directionUp
-      ? `${targetRect.top - popoverRect.height + window.pageYOffset}px`
-      : `${targetRect.top + targetRect.height + window.pageYOffset}px`,
+    ...getTopPosition(targetRect, popoverRect),
+  };
+};
+
+export const positionRight: Position = (targetRect, popoverRect) => {
+  if (!targetRect || !popoverRect) {
+    return {};
+  }
+
+  const { directionLeft } = getCollisions(targetRect, popoverRect);
+  return {
+    left: directionLeft
+      ? `${targetRect.left + window.pageXOffset}px`
+      : `${targetRect.right - popoverRect.width + window.pageXOffset}px`,
+    ...getTopPosition(targetRect, popoverRect),
   };
 };
 
@@ -113,13 +131,10 @@ export const positionMatchWidth: Position = (targetRect, popoverRect) => {
     return {};
   }
 
-  const { directionUp } = getCollisions(targetRect, popoverRect);
   return {
     width: targetRect.width,
     left: targetRect.left,
-    top: directionUp
-      ? `${targetRect.top - popoverRect.height + window.pageYOffset}px`
-      : `${targetRect.top + targetRect.height + window.pageYOffset}px`,
+    ...getTopPosition(targetRect, popoverRect),
   };
 };
 
@@ -139,9 +154,10 @@ function getCollisions(
   };
 
   const directionRight = collisions.right && !collisions.left;
+  const directionLeft = collisions.left && !collisions.right;
   const directionUp = collisions.bottom && !collisions.top;
 
-  return { directionRight, directionUp };
+  return { directionRight, directionLeft, directionUp };
 }
 
 // Heads up, my jQuery past haunts this function. This hook scopes the tab


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other


- Adds helper `positionRight` to set default alignment
of popover to the right
- Create `getTopPosition` abstraction since same logic
is now used in 3 places

