### PR TITLE
[@reach/dialog] Pass `allowPinchZoom` prop from Dialog to DialogOverlay

### DIFF
--- a/packages/dialog/examples/basic-ts.example.tsx
+++ b/packages/dialog/examples/basic-ts.example.tsx
@@ -9,7 +9,7 @@ function Example() {
   return (
     <div>
       <button onClick={() => setShowDialog(true)}>Show Dialog</button>
-      <Dialog aria-label="Announcement" isOpen={showDialog}>
+      <Dialog aria-label="Announcement" isOpen={showDialog} allowPinchZoom>
         <button onClick={() => setShowDialog(false)}>Close Dialog</button>
         <p>This is killer!</p>
         <input type="text" />

--- a/packages/dialog/examples/basic.example.js
+++ b/packages/dialog/examples/basic.example.js
@@ -9,7 +9,7 @@ function Example() {
   return (
     <div>
       <button onClick={() => setShowDialog(true)}>Show Dialog</button>
-      <Dialog aria-label="Announcement" isOpen={showDialog}>
+      <Dialog aria-label="Announcement" isOpen={showDialog} allowPinchZoom>
         <button onClick={() => setShowDialog(false)}>Close Dialog</button>
         <p>This is killer!</p>
         <input type="text" />

--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -208,12 +208,13 @@ if (__DEV__) {
  * @see Docs https://reacttraining.com/reach-ui/dialog#dialog
  */
 export const Dialog = forwardRef<HTMLDivElement, DialogProps>(function Dialog(
-  { isOpen, onDismiss = noop, initialFocusRef, ...props },
+  { isOpen, onDismiss = noop, initialFocusRef, allowPinchZoom, ...props },
   forwardedRef
 ) {
   return (
     <DialogOverlay
       initialFocusRef={initialFocusRef}
+      allowPinchZoom={allowPinchZoom}
       isOpen={isOpen}
       onDismiss={onDismiss}
     >


### PR DESCRIPTION
When passing `allowPinchZoom` to `Dialog` as per the docs, the prop is not passed on to `DialogOverlay`, instead it's spread onto `DialogContent` and then on to the DOM, causing a development warning from ReactDOM (`React does not recognize the `allowPinchZoom` prop...`).

This PR instead passes it on to `DialogContent`, which I assume is the intended behaviour. Didn't add any tests but did add it to the `Basic` storybook example to verify the fix. Also tested it with my own app.

---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other
