### PR TITLE
[docs] Fix glitch: MenuButton uses onMouseDown prop instead on onClick

### DIFF
--- a/website/src/pages/menu-button.mdx
+++ b/website/src/pages/menu-button.mdx
@@ -176,7 +176,7 @@ If you'd like to target when the menu is open use `aria-expanded`:
 | ------------------------------------------ | ---------------------- | -------- |
 | [`button` props](#menubutton-button-props) |                        |          |
 | [`children`](#menubutton-children)         | `node`                 | false    |
-| `onClick`                                  | `preventableEventFunc` | false    |
+| `onMouseDown`                              | `preventableEventFunc` | false    |
 | `onKeyDown`                                | `preventableEventFunc` | false    |
 
 ##### MenuButton `button` props


### PR DESCRIPTION
Spent a few minutes not understanding why I could not prevent the event when using onClick ;)

-------------------------

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
