### PR TITLE
Docs: fix animation examples to not use HOCs in the render

### DIFF
--- a/website/src/pages/animation.mdx
+++ b/website/src/pages/animation.mdx
@@ -111,9 +111,9 @@ function Example() {
 
 ```jsx
 // jsx-demo
+let AnimatedDialogOverlay = animated(DialogOverlay);
+let AnimatedDialogContent = animated(DialogContent);
 function Example(props) {
-  let AnimatedDialogOverlay = animated(DialogOverlay);
-  let AnimatedDialogContent = animated(DialogContent);
   const [showDialog, setShowDialog] = React.useState(false);
   const transitions = useTransition(showDialog, null, {
     from: { opacity: 0, y: -10 },

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -461,9 +461,9 @@ If you'd like to animate the content, give [React Spring](https://github.com/drc
 
 ```jsx
 // jsx-demo
+const AnimatedDialogOverlay = animated(DialogOverlay);
+const AnimatedDialogContent = animated(DialogContent);
 function Example(props) {
-  const AnimatedDialogOverlay = animated(DialogOverlay);
-  const AnimatedDialogContent = animated(DialogContent);
   const [showDialog, setShowDialog] = React.useState(false);
   const transitions = useTransition(showDialog, null, {
     from: { opacity: 0, y: -10 },


### PR DESCRIPTION
Hi there, my first PR ever :) So I copy and pasted an animation example from your website that caused me a good hour of hair pulling and the reason was, an animation _inside_ the animated dialog wasn’t working. The cause was that the AnimatedDialogOverlay and AnimatedDialogContent were being recreated on every render because of using the animated HOC inside the render. Hopefully this small docs fix will help future users of the library.

Thanks.

ps. sorry for the extra commits, I was editing this in the Github editor 😅

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other