### PR TITLE
[Combobox] Remove unused __ComboboxPopoverProps type

### DIFF
--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -617,15 +617,6 @@ if (__DEV__) {
   ComboboxPopover.displayName = "ComboboxPopover";
 }
 
-export type __ComboboxPopoverProps = {
-  targetRef?: any;
-  positionMatchWidth?: {
-    width: string;
-    left: number;
-    top: string;
-  };
-};
-
 /**
  * @see Docs https://reacttraining.com/reach-ui/combobox#comboboxpopover-props
  */


### PR DESCRIPTION
The use of the private type was replaced by `Partial<PopoverProps>` in 628790f. I don't believe the type is necessary as a named export any more. However, because it was a named export, removal of this type should likely be considered part of a breaking change update to the package in case any consumer was relying on the type.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other: remove unused code