### PR TITLE
[Combobox] Add popover visibility hook for styling

### DIFF
--- a/packages/combobox/examples/using-popover-visibility-hook.example.tsx
+++ b/packages/combobox/examples/using-popover-visibility-hook.example.tsx
@@ -1,0 +1,62 @@
+import React from "react";
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxOption,
+  ComboboxPopover,
+  ComboboxInputProps,
+  useComboboxContext,
+} from "@reach/combobox";
+import "@reach/combobox/styles.css";
+
+let name = "Using Popover Visibility Hook (TS)";
+
+const StyledComboboxInput = (props: ComboboxInputProps) => {
+  const { isExpanded } = useComboboxContext();
+
+  return (
+    <ComboboxInput
+      {...props}
+      style={{
+        width: 400,
+        fontSize: "100%",
+        padding: "0.33rem",
+        backgroundColor: isExpanded ? "cornsilk" : "aliceblue",
+      }}
+    />
+  );
+};
+
+function Example() {
+  return (
+    <div>
+      <h2 id="choose-a-fruit">Choose a fruit</h2>
+      <p>Input styles change based on popover visibility!</p>
+      <Combobox>
+        <StyledComboboxInput aria-labelledby="choose-a-fruit" />
+        <ComboboxPopover style={popupStyle}>
+          <ComboboxList>
+            <ComboboxOption value="Apple" />
+            <ComboboxOption value="Banana" />
+            <ComboboxOption value="Orange" />
+            <ComboboxOption value="Pineapple" />
+            <ComboboxOption value="Kiwi" />
+            <button>Hi</button>
+          </ComboboxList>
+        </ComboboxPopover>
+      </Combobox>
+    </div>
+  );
+}
+
+Example.story = { name };
+export const Comp = Example;
+export default { title: "Combobox" };
+
+////////////////////////////////////////////////////////////////////////////////
+
+const popupStyle = {
+  boxShadow: "0px 2px 6px hsla(0, 0%, 0%, 0.15)",
+  border: "none",
+};

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -746,7 +746,6 @@ export const ComboboxOption = forwardRefWithAs<ComboboxOptionProps, "li">(
           // onBlur will work as intended
           tabIndex={-1}
           onClick={wrapEvent(onClick, handleClick)}
-          // @ts-ignore
           children={children || <ComboboxOptionText />}
         />
       </OptionContext.Provider>
@@ -1158,11 +1157,27 @@ export function escapeRegexp(str: string) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
+export function useComboboxContext(): ComboboxContextValue {
+  let { isVisible: isExpanded } = useContext(ComboboxContext);
+  return useMemo(
+    () => ({
+      isExpanded,
+    }),
+    [isExpanded]
+  );
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
 // Well alright, you made it all the way here to like 1100 lines of code (geez,
 // what the heck?). Have a great day :D
 
 ////////////////////////////////////////////////////////////////////////////////
 // Types
+
+export type ComboboxContextValue = {
+  isExpanded: boolean;
+};
 
 type DescendantProps = {
   value: ComboboxValue;


### PR DESCRIPTION
Influenced by the [Reach UI Philosophy][1] on exposing state for JS styling, and by the [recent addition of useTabsContext][2].

```jsx
const StyledComboboxInput = (props) => {
  const { isExpanded } = useComboboxContext();

  return (
    <ComboboxInput
      {...props}
      style={{ backgroundColor: isExpanded ? "blue" : "red" }}
    />
  );
};
```

The real-world desire for this feature comes from a design I received that changes the inputs bottom border radii when the popover is open. You can see I tried to implement it based on input focus and value change, but this doesn't handle every case and adds unnecessary state and complexity.

Before hook
<img width="80%" src="https://user-images.githubusercontent.com/3409645/76039668-f6e48980-5f01-11ea-9c5a-a986c5358def.gif" />

After hook
<img width="60%" src="https://user-images.githubusercontent.com/3409645/77260676-c8c3b100-6c46-11ea-8083-33383be44206.gif" />


---

[1]: https://gist.github.com/ryanflorence/e5c794e6093d16a69fa88d2112a292f7#exposing-state-for-js-styling
[2]: https://github.com/reach/reach-ui/blob/d4bcfc73f27e6e618ec2eb2b0154a58bc17496f0/packages/tabs/src/index.tsx#L685-L695

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
