### PR TITLE
[Combobox] Add aria-label to examples

### DIFF
--- a/packages/combobox/__tests__/combobox.test.tsx
+++ b/packages/combobox/__tests__/combobox.test.tsx
@@ -72,6 +72,101 @@ describe("<Combobox />", () => {
       });
       expect(results).toHaveNoViolations();
     });
+
+    it("should forward aria-label from Combobox to ComboboxInput", () => {
+      let { getByRole } = render(<ComboboxExample />);
+      let input = getByRole("combobox");
+
+      expect(input).toHaveAttribute("aria-label");
+      expect(input.getAttribute("aria-label")).toBe("choose a fruit");
+
+      function ComboboxExample() {
+        return (
+          <Combobox aria-label="choose a fruit">
+            <ComboboxInput />
+            <ComboboxPopover>
+              <ComboboxList>
+                <ComboboxOption value="Apple" />
+                <ComboboxOption value="Banana" />
+              </ComboboxList>
+            </ComboboxPopover>
+          </Combobox>
+        );
+      }
+    });
+
+    it("should forward aria-labelledby from Combobox to ComboboxInput", () => {
+      let { getByRole } = render(<ComboboxExample />);
+      let input = getByRole("combobox");
+
+      expect(input).toHaveAttribute("aria-labelledby");
+      expect(input.getAttribute("aria-labelledby")).toBe("choose-a-fruit");
+
+      function ComboboxExample() {
+        return (
+          <div>
+            <h1 id="choose-a-fruit">Choose a Fruit</h1>
+            <Combobox aria-labelledby="choose-a-fruit">
+              <ComboboxInput />
+              <ComboboxPopover>
+                <ComboboxList>
+                  <ComboboxOption value="Apple" />
+                  <ComboboxOption value="Banana" />
+                </ComboboxList>
+              </ComboboxPopover>
+            </Combobox>
+          </div>
+        );
+      }
+    });
+
+    it("aria-label set on ComboboxInput should take precedence", () => {
+      let { getByRole } = render(<ComboboxExample />);
+      let input = getByRole("combobox");
+
+      expect(input).toHaveAttribute("aria-label");
+      expect(input.getAttribute("aria-label")).toBe("label set on input");
+
+      function ComboboxExample() {
+        return (
+          <Combobox aria-label="label set on combobox">
+            <ComboboxInput aria-label="label set on input" />
+            <ComboboxPopover>
+              <ComboboxList>
+                <ComboboxOption value="Apple" />
+                <ComboboxOption value="Banana" />
+              </ComboboxList>
+            </ComboboxPopover>
+          </Combobox>
+        );
+      }
+    });
+
+    it("aria-labelledby set on ComboboxInput should take precedence", () => {
+      let { getByRole } = render(<ComboboxExample />);
+      let input = getByRole("combobox");
+
+      expect(input).toHaveAttribute("aria-labelledby");
+      expect(input.getAttribute("aria-labelledby")).toBe("used-for-label");
+
+      function ComboboxExample() {
+        return (
+          <div>
+            <p id="not-used-for-label">choose a fruit</p>
+            <p id="used-for-label">choose a fruit</p>
+            <Combobox aria-labelledby="not-used-for-label">
+              <ComboboxInput aria-labelledby="used-for-label" />
+              <ComboboxPopover>
+                <ComboboxList>
+                  <ComboboxOption value="Apple" />
+                  <ComboboxOption value="Banana" />
+                </ComboboxList>
+              </ComboboxPopover>
+            </Combobox>
+          </div>
+        );
+      }
+    });
   });
 
   describe("user events", () => {

--- a/packages/combobox/examples/basic-ts.example.tsx
+++ b/packages/combobox/examples/basic-ts.example.tsx
@@ -4,7 +4,7 @@ import {
   ComboboxInput,
   ComboboxList,
   ComboboxOption,
-  ComboboxPopover
+  ComboboxPopover,
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "./use-throttle";
@@ -24,7 +24,7 @@ function Example() {
   return (
     <div>
       <h2>Clientside Search</h2>
-      <Combobox id="holy-smokes">
+      <Combobox id="holy-smokes" aria-label="choose a city">
         <ComboboxInput
           name="awesome"
           onChange={handleChange}
@@ -63,7 +63,7 @@ function useCityMatch(term: string) {
       term.trim() === ""
         ? null
         : matchSorter(cities, term, {
-            keys: [item => `${item.city}, ${item.state}`]
+            keys: [item => `${item.city}, ${item.state}`],
           }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [throttledTerm]
@@ -73,10 +73,10 @@ function useCityMatch(term: string) {
 const inputStyle = {
   width: 400,
   fontSize: "100%",
-  padding: "0.33rem"
+  padding: "0.33rem",
 };
 
 const popupStyle = {
   boxShadow: "0px 2px 6px hsla(0, 0%, 0%, 0.15)",
-  border: "none"
+  border: "none",
 };

--- a/packages/combobox/examples/basic.example.js
+++ b/packages/combobox/examples/basic.example.js
@@ -4,7 +4,7 @@ import {
   ComboboxInput,
   ComboboxList,
   ComboboxOption,
-  ComboboxPopover
+  ComboboxPopover,
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
@@ -24,7 +24,7 @@ function Example() {
   return (
     <div>
       <h2>Clientside Search</h2>
-      <Combobox id="holy-smokes">
+      <Combobox id="holy-smokes" aria-label="choose a city">
         <ComboboxInput onChange={handleChange} style={inputStyle} />
         {results && (
           <ComboboxPopover style={popupStyle}>
@@ -59,7 +59,7 @@ function useCityMatch(term) {
       term.trim() === ""
         ? null
         : matchSorter(cities, term, {
-            keys: [item => `${item.city}, ${item.state}`]
+            keys: [item => `${item.city}, ${item.state}`],
           }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [throttledTerm]
@@ -69,10 +69,10 @@ function useCityMatch(term) {
 const inputStyle = {
   width: 400,
   fontSize: "100%",
-  padding: "0.33rem"
+  padding: "0.33rem",
 };
 
 const popupStyle = {
   boxShadow: "0px 2px 6px hsla(0, 0%, 0%, 0.15)",
-  border: "none"
+  border: "none",
 };

--- a/packages/combobox/examples/controlled-ts.example.tsx
+++ b/packages/combobox/examples/controlled-ts.example.tsx
@@ -33,7 +33,7 @@ function Example() {
       <h2>Clientside Search</h2>
       <p>Selection: {selection}</p>
       <p>Term: {term}</p>
-      <Combobox onSelect={handleSelect}>
+      <Combobox onSelect={handleSelect} aria-label="choose a city">
         <ComboboxInput
           ref={ref}
           value={term}

--- a/packages/combobox/examples/controlled.example.js
+++ b/packages/combobox/examples/controlled.example.js
@@ -33,7 +33,7 @@ function Example() {
       <h2>Clientside Search</h2>
       <p>Selection: {selection}</p>
       <p>Term: {term}</p>
-      <Combobox onSelect={handleSelect}>
+      <Combobox onSelect={handleSelect} aria-label="choose a city">
         <ComboboxInput
           ref={ref}
           value={term}

--- a/packages/combobox/examples/lots-of-elements.example.js
+++ b/packages/combobox/examples/lots-of-elements.example.js
@@ -4,7 +4,7 @@ import {
   ComboboxInput,
   ComboboxList,
   ComboboxOption,
-  ComboboxPopover
+  ComboboxPopover,
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
@@ -25,7 +25,7 @@ function Example() {
     <div>
       <h2>Clientside Search</h2>
 
-      <Combobox>
+      <Combobox aria-label="choose a city">
         <ComboboxInput autocomplete={false} onChange={handleChange} />
         {results && (
           <ComboboxPopover>
@@ -76,7 +76,7 @@ function useCityMatch(term) {
       term.trim() === ""
         ? null
         : matchSorter(cities, term, {
-            keys: [item => `${item.city}, ${item.state}`]
+            keys: [item => `${item.city}, ${item.state}`],
           }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [throttledTerm]

--- a/packages/combobox/examples/no-popover.example.js
+++ b/packages/combobox/examples/no-popover.example.js
@@ -4,7 +4,7 @@ import {
   ComboboxInput,
   ComboboxList,
   ComboboxPopover,
-  ComboboxOption
+  ComboboxOption,
 } from "@reach/combobox";
 import matchSorter from "match-sorter";
 import { useThrottle } from "use-throttle";
@@ -24,7 +24,7 @@ function Example() {
   return (
     <div>
       <h2>No Portal</h2>
-      <Combobox style={{ width: "400px" }}>
+      <Combobox style={{ width: "400px" }} aria-label="choose a city">
         <ComboboxInput onChange={handleChange} />
         {results && (
           <ComboboxPopover portal={false}>
@@ -44,7 +44,7 @@ function Example() {
                   margin: 0,
                   color: "#454545",
                   padding: "0.25rem 1rem 0.75rem 1rem",
-                  fontStyle: "italic"
+                  fontStyle: "italic",
                 }}
               >
                 No results :(
@@ -70,7 +70,7 @@ function useCityMatch(term) {
       term.trim() === ""
         ? null
         : matchSorter(cities, term, {
-            keys: [item => `${item.city}, ${item.state}`]
+            keys: [item => `${item.city}, ${item.state}`],
           }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [throttledTerm]

--- a/packages/combobox/examples/open-on-focus.example.js
+++ b/packages/combobox/examples/open-on-focus.example.js
@@ -32,7 +32,7 @@ function Example() {
     <div>
       <h2>Clientside Search</h2>
       <p>Selection: {selection}</p>
-      <Combobox openOnFocus onSelect={handleSelect}>
+      <Combobox openOnFocus onSelect={handleSelect} aria-label="choose a city">
         <ComboboxInput
           onChange={handleChange}
           value={term}

--- a/packages/combobox/examples/token-input.js
+++ b/packages/combobox/examples/token-input.js
@@ -152,7 +152,13 @@ function ExampleToken({ value, ...props }) {
 
 function ExampleTokenbox({ onSelect, ...props }) {
   const handleSelect = () => {};
-  return <Combobox onSelect={wrapEvent(onSelect, handleSelect)} {...props} />;
+  return (
+    <Combobox
+      onSelect={wrapEvent(onSelect, handleSelect)}
+      aria-label="choose a city"
+      {...props}
+    />
+  );
 }
 
 function ExampleTokenInput({ onKeyDown, ...props }) {

--- a/packages/combobox/examples/with-button.example.js
+++ b/packages/combobox/examples/with-button.example.js
@@ -26,7 +26,7 @@ function Example() {
   return (
     <div>
       <h2>No Portal</h2>
-      <Combobox>
+      <Combobox aria-label="choose a city">
         <ComboboxInput style={{ width: "300px" }} onChange={handleChange} />
         <ComboboxButton>
           <VisuallyHidden>Toggle the list of cities</VisuallyHidden>

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -265,7 +265,15 @@ const OptionContext = createNamedContext(
  */
 export const Combobox = forwardRefWithAs<ComboboxProps, "div">(
   function Combobox(
-    { onSelect, openOnFocus = false, children, as: Comp = "div", ...rest },
+    {
+      onSelect,
+      openOnFocus = false,
+      children,
+      as: Comp = "div",
+      "aria-label": ariaLabel,
+      "aria-labelledby": ariaLabelledby,
+      ...rest
+    },
     forwardedRef
   ) {
     let [options, setOptions] = useDescendants<HTMLElement, DescendantProps>();
@@ -319,6 +327,8 @@ export const Combobox = forwardRefWithAs<ComboboxProps, "div">(
       popoverRef,
       state,
       transition,
+      ariaLabel,
+      ariaLabelledby,
     };
 
     useEffect(() => checkStyles("combobox"), []);
@@ -360,6 +370,16 @@ export type ComboboxProps = {
    * @see Docs https://reacttraining.com/reach-ui/combobox#combobox-openonfocus
    */
   openOnFocus?: boolean;
+  /**
+   * Defines a string value that labels the current element.
+   * @see Docs https://reacttraining.com/reach-ui/combobox#accessibility
+   */
+  "aria-label"?: string;
+  /**
+   * Identifies the element (or elements) that labels the current element.
+   * @see Docs https://reacttraining.com/reach-ui/combobox#accessibility
+   */
+  "aria-labelledby"?: string;
 };
 
 if (__DEV__) {
@@ -412,6 +432,8 @@ export const ComboboxInput = forwardRefWithAs<ComboboxInputProps, "input">(
       autocompletePropRef,
       openOnFocus,
       isVisible,
+      ariaLabel,
+      ariaLabelledby,
     } = useContext(ComboboxContext);
 
     let ref = useForkedRef(inputRef, forwardedRef);
@@ -508,6 +530,8 @@ export const ComboboxInput = forwardRefWithAs<ComboboxInputProps, "input">(
         aria-controls={listboxId}
         aria-expanded={isVisible}
         aria-haspopup="listbox"
+        aria-label={ariaLabel}
+        aria-labelledby={ariaLabelledby}
         role="combobox"
         {...props}
         data-reach-combobox-input=""
@@ -1186,6 +1210,8 @@ interface IComboboxContext {
   persistSelectionRef: React.MutableRefObject<any>;
   isVisible: boolean;
   openOnFocus: boolean;
+  ariaLabel?: string;
+  ariaLabelledby?: string;
 }
 
 type Transition = (event: MachineEventType, payload?: any) => any;

--- a/website/src/pages/combobox.mdx
+++ b/website/src/pages/combobox.mdx
@@ -48,6 +48,40 @@ import {
 import "@reach/combobox/styles.css";
 ```
 
+## Accessibility
+
+Reach UI aims to handle most ARIA and accessibility concerns so that developers
+don't have to worry about it. Labeling is often the one thing Reach can't do for
+folks by default since there a many ways to accomplish it and some of those ways
+require app-level knowledge.
+
+However, we still aim to make accessibility as easy as possible. Labels for the
+compound component can go on the parent unless there's a good reason to not provide
+this pattern for a specific component.
+
+For instance, instead of adding `aria-label` to `<ComboboxInput>`, we can add it
+to `<Combobox>`. The same goes for `aria-labelledby`.
+
+```jsx
+<Combobox aria-label="choose a fruit">
+  <ComboboxInput />
+  <ComboboxPopover>
+    <ComboboxList>
+      <ComboboxOption value="Apple" />
+      <ComboboxOption value="Banana" />
+    </ComboboxList>
+  </ComboboxPopover>
+</Combobox>
+```
+
+One benefit reaped from this pattern is that it alleviates the need for developers
+to know about precisely which `aria-*` attributes belong on which piece of a compound
+component—just pass all `aria-*` attributes to the parent and let Reach handle putting
+it in the proper place.
+
+Another benefit is that if the ARIA spec changes in the future (as it did from
+1.1 to 1.2 for Combobox) Reach doesn't have to introduce a breaking API change.
+
 ## Examples
 
 To get you started, let's take a look at a few examples that grow from simple to complex, after the examples you can see the API for each component.
@@ -62,10 +96,10 @@ function Example() {
   return (
     <div>
       <h4 id="demo">Basic, Fixed List Combobox</h4>
-      <Combobox>
-        <ComboboxInput aria-labelledby="demo" />
+      <Combobox aria-labelledby="demo">
+        <ComboboxInput />
         <ComboboxPopover>
-          <ComboboxList aria-labelledby="demo">
+          <ComboboxList>
             <ComboboxOption value="Apple" />
             <ComboboxOption value="Banana" />
             <ComboboxOption value="Orange" />
@@ -87,14 +121,13 @@ Sometimes your items need to be more than just text, in these cases you can pass
 // jsx-demo
 function Example() {
   return (
-    <Combobox>
+    <Combobox aria-label="custom option demo">
       <ComboboxInput
         placeholder="Custom Option Rendering"
-        aria-label="custom option demo"
         style={{ width: 300 }}
       />
       <ComboboxPopover>
-        <ComboboxList aria-label="custom option demo">
+        <ComboboxList>
           <ComboboxOption value="Apple">
             🍎 <ComboboxOptionText />
           </ComboboxOption>
@@ -138,16 +171,15 @@ There is nothing special about managing state for a combobox, it's like managing
     return (
       <div>
         <h4>Clientside Search</h4>
-        <Combobox>
+        <Combobox aria-label="Cities">
           <ComboboxInput
-            aria-label="Cities"
             className="city-search-input"
             onChange={handleChange}
           />
           {results && (
             <ComboboxPopover className="shadow-popup">
               {results.length > 0 ? (
-                <ComboboxList aria-label="Cities">
+                <ComboboxList>
                   {results.slice(0, 10).map((result, index) => (
                     <ComboboxOption
                       key={index}
@@ -199,11 +231,10 @@ This is the same demo as above, except this time we're going to a server to get 
     };
 
     return (
-      <Combobox>
+      <Combobox aria-label="Cities">
         <ComboboxInput
           className="city-search-input"
           onChange={handleSearchTermChange}
-          aria-label="Cities"
         />
         {cities && (
           <ComboboxPopover className="shadow-popup">


### PR DESCRIPTION
> "If the combobox has a visible label and the combobox element is an HTML element that can be labelled using the HTML label element (e.g., the input element), it is labeled using the label element. Otherwise, if it has a visible label, the combobox element has aria-labelledby set to a value that refers to the labelling element. Otherwise, the combobox element has a label provided by aria-label." [source][1]

Given the number of ways to label the combobox, we cannot enforce or handle the aria programmatically. Outside of a runtime check, the best we can do is set good examples with proper labeling.

[1]: https://www.w3.org/TR/wai-aria-practices-1.2/#wai-aria-roles-states-and-properties-6

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other