### PR TITLE
[Listbox]: add expanded value for ListboxInput render function

### DIFF
--- a/packages/listbox/src/index.tsx
+++ b/packages/listbox/src/index.tsx
@@ -305,6 +305,7 @@ export const ListboxInput = forwardRef<
             ? children({
                 value: current.context.value,
                 valueLabel,
+                expanded: isExpanded(current.value),
               })
             : children}
         </div>
@@ -364,6 +365,7 @@ export type ListboxInputProps = Omit<
       | ((props: {
           value: ListboxValue | null;
           valueLabel: string | null;
+          expanded: boolean;
         }) => React.ReactNode);
     /**
      * The default value of an uncontrolled listbox.

--- a/website/src/pages/listbox.mdx
+++ b/website/src/pages/listbox.mdx
@@ -352,15 +352,15 @@ Please see the [styling guide](/styling).
 
 ##### ListboxInput `children`
 
-`children: React.ReactNode | ((props: { value: string | null; valueLabel: string | null; }) => React.ReactNode)`
+`children: React.ReactNode | ((props: { value: string | null; valueLabel: string | null; expanded: boolean; }) => React.ReactNode)`
 
 The composed listbox expects to receive `ListboxButton` and `ListboxPopover` as children. You can also pass in arbitrary wrapper elements if desired.
 
-If you want access to the listbox's current value and associated label, you can use a render function.
+If you want access to the listbox's current value and associated label, or its expanded state, you can use a render function.
 
 ```jsx
 <ListboxInput>
-  {({ value, valueLabel }) => (
+  {({ value, valueLabel, expanded }) => (
     <ListboxButton>
       <span data-value={value}>{valueLabel}</span>
     </ListboxButton>


### PR DESCRIPTION
This PR addresses #512 by providing an `expanded` field in the object passed to ListboxInput's render function. I matched the naming convention already present for ListboxButton's render function. I also updated the docs where using the component in this way is mentioned.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
