### PR TITLE
[Combobox] Remove escape-regexp dependency

### DIFF
--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -18,7 +18,6 @@
     "@reach/popover": "^0.9.0",
     "@reach/portal": "^0.9.0",
     "@reach/utils": "^0.9.0",
-    "escape-regexp": "0.0.1",
     "highlight-words-core": "1.2.2",
     "prop-types": "^15.7.2",
     "tslib": "^1.10.0"

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -49,7 +49,6 @@ import {
   useDescendants,
 } from "@reach/descendants";
 import { findAll } from "highlight-words-core";
-import escapeRegexp from "escape-regexp";
 import { useId } from "@reach/auto-id";
 import Popover, { positionMatchWidth, PopoverProps } from "@reach/popover";
 
@@ -1147,6 +1146,17 @@ const makeHash = (str: string) => {
   }
   return hash;
 };
+
+/**
+ * Escape regexp special characters in `str`
+ *
+ * @see https://github.com/component/escape-regexp/blob/5ce923c1510c9802b3da972c90b6861dd2829b6b/index.js
+ * @param str
+ */
+
+export function escapeRegexp(str: string) {
+  return String(str).replace(/([.*+?=^!:${}()|[\]/\\])/g, "\\$1");
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -6884,11 +6884,6 @@ escape-html@~1.0.3:
   resolved "https://registry.yarnpkg.com/escape-html/-/escape-html-1.0.3.tgz#0258eae4d3d0c0974de1c169188ef0051d1d1988"
   integrity sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg=
 
-escape-regexp@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/escape-regexp/-/escape-regexp-0.0.1.tgz#f44bda12d45bbdf9cb7f862ee7e4827b3dd32254"
-  integrity sha1-9EvaEtRbvfnLf4Yu5+SCez3TIlQ=
-
 escape-string-regexp@1.0.5, escape-string-regexp@^1.0.2, escape-string-regexp@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"


### PR DESCRIPTION
## Summary
The [escape-regexp package](https://github.com/component/escape-regexp) fails approval when trying to detect the license under which the project is distributed.

![image](https://user-images.githubusercontent.com/3409645/76913892-95afa500-6875-11ea-9cba-47812bee9307.png)

The package has not been touched in 7 years, and implements a single-line function that can be copied directly into source.

---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other: removes unnecessary old dependency