### PR TITLE
Docs: Remove obsolete `as` prop from MenuButton documentation

### DIFF
--- a/website/src/pages/menu-button.mdx
+++ b/website/src/pages/menu-button.mdx
@@ -197,14 +197,6 @@ Any props not listed above will be spread onto the underlying button element. Yo
 </Menu>
 ```
 
-##### MenuButton `as`
-
-`as?: keyof JSX.IntrinsicElements | React.ComponentType`
-
-A string representing an HTML element or a React component that will tell the `MenuButton` what underlying element to render. Defaults to `button`.
-
-> **NOTE:** Many semantic elements, such as `button` elements, have meaning to assistive devices and browsers that provide context for the user and, in many cases, provide or restrict interactive behaviors. Use caution when overriding our defaults and make sure that the element you choose to render provides the same experience for all users. While this prop is useful for passing custom implementations, such as styled or design-system components, using anything that renders the wrong semantic HTML element will require stubbing specific behaviors and attributes. This is highly discouraged.
-
 ##### MenuButton `children`
 
 `children: React.ReactNode`


### PR DESCRIPTION
Hello!

Thank you for the project. I've noticed the `as` prop in MenuButton documentation and found out it doesn't exist. I spend some time trying to understand what I'm doing wrong and looking for related issues, and found https://github.com/reach/reach-ui/pull/97 . So if I understand it correctly the `as` prop was postponed. In this case I would like to provide a fix, removing the mention of this prop for now.

Sincerely,
Nikolay.