### PR TITLE
Docs: Fix Rect-Props hrefs

### DIFF
--- a/website/src/pages/rect.mdx
+++ b/website/src/pages/rect.mdx
@@ -76,11 +76,11 @@ Render prop component for use in class components to observe element measurement
 
 #### Rect Props
 
-| Prop                  | Type |
-| --------------------- | ---- |
-| [children](#children) | func |
-| [observe](#observe)   | bool |
-| [onChange](#onchange) | func |
+| Prop                       | Type |
+| -------------------------- | ---- |
+| [children](#rect-children) | func |
+| [observe](#rect-observe)   | bool |
+| [onChange](#rect-onchange) | func |
 
 ##### Rect children
 


### PR DESCRIPTION
Just noticed that the `props` links did not match the markdown-generated URLs for the docs of `@reach/rect`

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other
