### PR TITLE
[Combobox] Clear value when input focused after interacting with popover

### DIFF
--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -147,6 +147,7 @@ const stateChart: StateChart = {
     },
     [INTERACTING]: {
       on: {
+        [CLEAR]: IDLE,
         [CHANGE]: SUGGESTING,
         [FOCUS]: SUGGESTING,
         [BLUR]: IDLE,


### PR DESCRIPTION
## Summary

**Before**

Typing in the input, tabbing to an interactive element in the listbox, focusing the input again, then attempting to delete the entire input value with <kbd>⌘</kbd> + <kbd>⌫</kbd> ("command + backspace" on macOS) is a noop for the input value. Notice that the controlled value is updated properly.

![combobox-before](https://user-images.githubusercontent.com/3409645/79028319-63c3f280-7b44-11ea-809a-81080c504a3a.gif)

**After**

Same sequence as above works as expected—the value is properly cleared on <kbd>⌘</kbd> + <kbd>⌫</kbd>.

![combobox-after](https://user-images.githubusercontent.com/3409645/79028324-67f01000-7b44-11ea-83d3-ab78752a0994.gif)

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other