### PR TITLE
[MenuButton] Don't default to focusing a MenuItem when using mouse

### DIFF
--- a/packages/menu-button/__tests__/menu-button.test.tsx
+++ b/packages/menu-button/__tests__/menu-button.test.tsx
@@ -22,7 +22,7 @@ describe("<MenuButton />", () => {
     it("should mount with render props", () => {
       let { queryByRole } = render(
         <Menu>
-          {props => (
+          {(props) => (
             <Fragment>
               <MenuButton>
                 {props.isExpanded ? "Close" : "Open"} Actions
@@ -113,7 +113,7 @@ describe("<MenuButton />", () => {
         </Menu>
       );
 
-      act(() => void clickButton(getByRole("button")));
+      act(() => void fireEvent.keyDown(getByRole("button"), { key: " " }));
       act(() => void fireEvent.keyDown(getByText("Download"), { key: " " }));
       expect(getByRole("button")).toHaveFocus();
     });
@@ -128,7 +128,7 @@ describe("<MenuButton />", () => {
         </Menu>
       );
 
-      act(() => void clickButton(getByRole("button")));
+      act(() => void fireEvent.keyDown(getByRole("button"), { key: "Enter" }));
       act(() => {
         fireEvent.keyDown(getByText("Download"), {
           key: "Enter",

--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -53,6 +53,7 @@ const CLEAR_SELECTION_INDEX = "CLEAR_SELECTION_INDEX";
 const CLICK_MENU_ITEM = "CLICK_MENU_ITEM";
 const CLOSE_MENU = "CLOSE_MENU";
 const OPEN_MENU_AT_FIRST_ITEM = "OPEN_MENU_AT_FIRST_ITEM";
+const OPEN_MENU_CLEARED = "OPEN_MENU_CLEARED";
 const SEARCH_FOR_ITEM = "SEARCH_FOR_ITEM";
 const SELECT_ITEM_AT_INDEX = "SELECT_ITEM_AT_INDEX";
 const SET_BUTTON_ID = "SET_BUTTON_ID";
@@ -258,7 +259,7 @@ export const MenuButton = forwardRefWithAs<MenuButtonProps, "button">(
       } else if (isExpanded) {
         dispatch({ type: CLOSE_MENU, payload: { buttonRef } });
       } else {
-        dispatch({ type: OPEN_MENU_AT_FIRST_ITEM });
+        dispatch({ type: OPEN_MENU_CLEARED });
       }
     }
 
@@ -986,6 +987,7 @@ type MenuButtonAction =
   | { type: "CLICK_MENU_ITEM" }
   | { type: "CLOSE_MENU"; payload: { buttonRef: ButtonRef } }
   | { type: "OPEN_MENU_AT_FIRST_ITEM" }
+  | { type: "OPEN_MENU_CLEARED" }
   | {
       type: "SELECT_ITEM_AT_INDEX";
       payload: { max?: number; min?: number; index: number };
@@ -1026,6 +1028,12 @@ function reducer(
         ...state,
         isExpanded: true,
         selectionIndex: 0,
+      };
+    case OPEN_MENU_CLEARED:
+      return {
+        ...state,
+        isExpanded: true,
+        selectionIndex: -1,
       };
     case SELECT_ITEM_AT_INDEX:
       if (action.payload.index >= 0) {


### PR DESCRIPTION
Fixes #507 

![menubutton-click-no-select](https://user-images.githubusercontent.com/9437625/79175069-af87cd80-7dca-11ea-97d7-413e1cc3762b.gif)

Notably, this changes two tests for `menu-button`, as they relied on the old behaviour, just clicking the button and firing a `keyDown`, assuming that would select the first item. Since they were testing usage of Space and Enter respectively, I made them use those respective buttons to open the menu, which still does automatically focus the first item.

---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
