### PR TITLE
[Listbox] Hide input that documentation claims is hidden

### DIFF
--- a/packages/listbox/__tests__/listbox.test.tsx
+++ b/packages/listbox/__tests__/listbox.test.tsx
@@ -197,6 +197,10 @@ describe("<Listbox />", () => {
           </Listbox>
         );
         expect(container.querySelector("input")).toBeTruthy();
+        expect(container.querySelector("input")).toHaveAttribute(
+          "type",
+          "hidden"
+        );
       });
     });
 
@@ -218,7 +222,12 @@ describe("<Listbox />", () => {
             </Listbox>
           </div>
         );
-        expect(container.querySelector("input")).toBeTruthy();
+        // Be careful not to match the `input[type=text]` added in this test
+        expect(container.querySelector("input[type=hidden]")).toBeTruthy();
+        expect(container.querySelector("input[type=hidden]")).toHaveAttribute(
+          "form",
+          "my-form"
+        );
       });
     });
 
@@ -232,6 +241,10 @@ describe("<Listbox />", () => {
           </Listbox>
         );
         expect(container.querySelector("input")).toBeTruthy();
+        expect(container.querySelector("input")).toHaveAttribute(
+          "type",
+          "hidden"
+        );
         expect(container.querySelector("input")).toHaveAttribute("required");
       });
     });

--- a/packages/listbox/__tests__/listbox.test.tsx
+++ b/packages/listbox/__tests__/listbox.test.tsx
@@ -196,11 +196,7 @@ describe("<Listbox />", () => {
             <ListboxOption value="lengua">Lengua</ListboxOption>
           </Listbox>
         );
-        expect(container.querySelector("input")).toBeTruthy();
-        expect(container.querySelector("input")).toHaveAttribute(
-          "type",
-          "hidden"
-        );
+        expect(container.querySelector("input")).not.toBeVisible();
       });
     });
 
@@ -222,12 +218,8 @@ describe("<Listbox />", () => {
             </Listbox>
           </div>
         );
-        // Be careful not to match the `input[type=text]` added in this test
-        expect(container.querySelector("input[type=hidden]")).toBeTruthy();
-        expect(container.querySelector("input[type=hidden]")).toHaveAttribute(
-          "form",
-          "my-form"
-        );
+        // Make sure to get the second input (not the one added in the test)
+        expect(container.querySelectorAll("input")[1]).not.toBeVisible();
       });
     });
 

--- a/packages/listbox/__tests__/listbox.test.tsx
+++ b/packages/listbox/__tests__/listbox.test.tsx
@@ -232,11 +232,7 @@ describe("<Listbox />", () => {
             <ListboxOption value="lengua">Lengua</ListboxOption>
           </Listbox>
         );
-        expect(container.querySelector("input")).toBeTruthy();
-        expect(container.querySelector("input")).toHaveAttribute(
-          "type",
-          "hidden"
-        );
+        expect(container.querySelector("input")).not.toBeVisible();
         expect(container.querySelector("input")).toHaveAttribute("required");
       });
     });

--- a/packages/listbox/src/index.tsx
+++ b/packages/listbox/src/index.tsx
@@ -331,7 +331,7 @@ export const ListboxInput = forwardRef<
             readOnly
             required={required}
             tabIndex={-1}
-            type="text"
+            type="hidden"
             value={state.context.value || ""}
           />
         )}


### PR DESCRIPTION
This PR fixes #569.

**Listbox** is not hiding the generated `input`. But documentation and tests indicate the rendered `input` is hidden. 

- This PR hides it by making it `type="hidden"`.
- Unit tests have been updated to ensure the input is hidden.
- No storybook was added because this is a bug fix. The change does hide the input that used to be visible in the `With a Form` storybook.

---
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
