### PR TITLE
Use type button by default in Tab component

### DIFF
--- a/packages/tabs/__tests__/tabs.test.tsx
+++ b/packages/tabs/__tests__/tabs.test.tsx
@@ -13,6 +13,46 @@ import {
 } from "@reach/tabs";
 
 describe("<Tabs />", () => {
+  describe("rendering", () => {
+    it("sets the button type to button by default", () => {
+      const { getByText } = render(
+        <div>
+          <Tabs>
+            <TabList>
+              <Tab>Tab 1</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <p>Panel 1</p>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </div>
+      );
+
+      expect(getByText("Tab 1")).toHaveAttribute("type", "button");
+    });
+
+    it("allows a custom button type", () => {
+      const { getByText } = render(
+        <div>
+          <Tabs>
+            <TabList>
+              <Tab type="submit">Tab 1</Tab>
+            </TabList>
+            <TabPanels>
+              <TabPanel>
+                <p>Panel 1</p>
+              </TabPanel>
+            </TabPanels>
+          </Tabs>
+        </div>
+      );
+
+      expect(getByText("Tab 1")).toHaveAttribute("type", "submit");
+    });
+  });
+
   describe("a11y", () => {
     it("should not have basic a11y issues", async () => {
       const { container } = render(

--- a/packages/tabs/src/index.tsx
+++ b/packages/tabs/src/index.tsx
@@ -455,6 +455,8 @@ export const Tab = forwardRefWithAs<
     context: TabsDescendantsContext,
     disabled: !!disabled,
   });
+  const htmlType =
+    Comp === "button" && props.type == null ? "button" : props.type;
 
   const isSelected = index === selectedIndex;
 
@@ -507,6 +509,7 @@ export const Tab = forwardRefWithAs<
       onClick={onSelect}
       onFocus={handleFocus}
       onBlur={handleBlur}
+      type={htmlType}
     >
       {children}
     </Comp>


### PR DESCRIPTION
This PR fixes https://github.com/reach/reach-ui/issues/165, it was first fixed in https://github.com/reach/reach-ui/commit/5f75dd525385fc2d800205ff99dae205a1bce6b4 but then broken in https://github.com/reach/reach-ui/commit/a2ab2be8b0ca122e3fa03a00e24d78b757b48e35.

I've added a couple of tests but I'm not sure if they're what you expect so feedback is welcome!
_________

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
