### PR TITLE
portal: fix TypeError when using hot-loader

### DIFF
--- a/packages/portal/src/index.tsx
+++ b/packages/portal/src/index.tsx
@@ -26,6 +26,8 @@ const Portal: React.FC<PortalProps> = ({ children, type = "reach-portal" }) => {
   let [, forceUpdate] = useState();
 
   useIsomorphicLayoutEffect(() => {
+    // This ref may be null when a hot-loader replaces components on the page
+    if (!mountNode.current) return;
     // It's possible that the content of the portal has, itself, been portaled.
     // In that case, it's important to append to the correct document element.
     const ownerDocument = mountNode.current!.ownerDocument;


### PR DESCRIPTION
Fixes #557 

This is just a simple fix for this bug. I verified that it fixed the bug and that hot-reloading now works without errors.

----------------
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [X] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
