### PR TITLE
fix(tabs): wait for TabPanel to mount before setting `hidden`

### DIFF
--- a/packages/tabs/src/index.tsx
+++ b/packages/tabs/src/index.tsx
@@ -608,6 +608,7 @@ export const TabPanel = forwardRefWithAs<TabPanelProps, "div">(
       TabsContext
     );
     let ownRef = useRef<HTMLElement | null>(null);
+    let isMountedRef = useRef<boolean>(false);
 
     let index = useDescendant({
       element: ownRef.current!,
@@ -623,12 +624,20 @@ export const TabPanel = forwardRefWithAs<TabPanelProps, "div">(
       isSelected ? selectedPanelRef : null
     );
 
+    React.useEffect(() => {
+      isMountedRef.current = true;
+    }, []);
+
     return (
       <Comp
         // Each element with role `tabpanel` has the property `aria-labelledby`
         // referring to its associated tab element.
         aria-labelledby={makeId(tabsId, "tab", index)}
-        hidden={!isSelected}
+        // During the initial render `isSelected` would be `false`
+        // and hide the children, which prevents focusing via refs on mount.
+        // As a workaround, we wait for the component to mount, and then set the `hidden` attribute.
+        // I guess this is hackish, but it works.
+        hidden={isMountedRef.current ? !isSelected : false}
         // Each element that contains the content panel for a tab has role
         // `tabpanel`.
         // https://www.w3.org/TR/wai-aria-practices-1.2/#tabpanel


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

<hr />

Closes #561

I don't know if this is the correct solution, but it seems to make sense (?) and work.