### PR TITLE
fix(website): remove redundant :root selector in app.scss of website

### DIFF
--- a/website/src/styles/app.scss
+++ b/website/src/styles/app.scss
@@ -22,24 +22,6 @@
   --table-cell-border-color: #eee;
 }
 
-:root {
-  --font-family-sans: -apple-system, BlinkMacSystemFont, Segoe UI, Roboto,
-    Oxygen, Ubuntu, Cantarell, Fira Sans, Droid Sans, Helvetica Neue, sans-serif;
-  --font-family-mono: "SFMono-Regular", Consolas, "Roboto Mono",
-    "Droid Sans Mono", "Liberation Mono", Menlo, Courier, monospace;
-  --error-color: #bf4a3f;
-  --primary-color: #1159a6;
-  --primary-color-bright: #007bff;
-  --primary-color-light: #3f94bf;
-  --body-color: #222;
-  --body-background: #fafafa;
-  --focus-outline-color: #1eaedb;
-  --input-background-color: #fff;
-  --input-border-color: #d1d1d1;
-  --rule-border-color: #e1e1e1;
-  --table-cell-border-color: #eee;
-}
-
 @keyframes slide-down {
   0% {
     opacity: 0;


### PR DESCRIPTION
### The :root selector was repeated twice in **app.scss** file of reach website, one of them have been removed
---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other
