### PR TITLE
fix(build): dont use `Array.flatMap`

### DIFF
--- a/scripts/build.ts
+++ b/scripts/build.ts
@@ -20,6 +20,7 @@ import {
   logError,
   cleanDistFolder,
   parseArgs,
+  flatten,
 } from "./utils";
 import { ScriptOpts, NormalizedOpts } from "./types";
 import * as fs from "fs-extra";
@@ -267,10 +268,10 @@ function createConfigItems(type: any, items: any[]) {
 function mergeConfigItems(type: any, ...configItemsToMerge: any[]) {
   const mergedItems: any[] = [];
 
-  configItemsToMerge.forEach(configItemToMerge => {
+  configItemsToMerge.forEach((configItemToMerge) => {
     configItemToMerge.forEach((item: any) => {
       const itemToMergeWithIndex = mergedItems.findIndex(
-        mergedItem => mergedItem.file.resolved === item.file.resolved
+        (mergedItem) => mergedItem.file.resolved === item.file.resolved
       );
 
       if (itemToMergeWithIndex === -1) {
@@ -307,13 +308,17 @@ if (process.env.NODE_ENV === 'production') {
 export async function createBuildConfigs(
   opts: NormalizedOpts
 ): Promise<RollupOptions[]> {
-  const allInputs = opts.input.flatMap((input: string) =>
-    createAllFormats(opts, input).map((options: ScriptOpts, index: number) => ({
-      ...options,
-      // We want to know if this is the first run for each entryfile
-      // for certain plugins (e.g. css)
-      writeMeta: index === 0,
-    }))
+  const allInputs = flatten(
+    flatten(opts.input as any).map((input: string) =>
+      createAllFormats(opts, input).map(
+        (options: ScriptOpts, index: number) => ({
+          ...options,
+          // We want to know if this is the first run for each entryfile
+          // for certain plugins (e.g. css)
+          writeMeta: index === 0,
+        })
+      )
+    )
   );
 
   return await Promise.all(

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -66,11 +66,7 @@ export async function getInputs(
       ? entries
       : (await isDir(resolveApp("src"))) && (await jsOrTs("src/index"))
   );
-  // We can't use `Array.flatMap` in CodeSandbox CI builds:
-  // https://github.com/reach/reach-ui/issues/586
-  return "flatMap" in Array
-    ? inputs.flatMap((file) => glob(file))
-    : [].concat.apply([], inputs).map((file) => glob(file));
+  return flatten(inputs).map((file) => glob(file));
 }
 
 export function getPackageName(opts: any) {
@@ -130,4 +126,8 @@ export async function cleanDistFolder() {
 export function parseArgs() {
   let { _, ...args } = mri(process.argv.slice(2));
   return args;
+}
+
+export function flatten(arr: any[][]): any[] {
+  return arr.reduce((flat, next) => flat.concat(next), []);
 }


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other

<hr />

Closes #586

I figured it's probably more straightforward to just drop `Array.flatMap` for now. We could instead check for `'flatMap' in Array` as well, but I don't see the point.