### PR TITLE
Fix tabs.mdx animated example

### DIFF
--- a/website/src/pages/tabs.mdx
+++ b/website/src/pages/tabs.mdx
@@ -763,28 +763,39 @@ With a little composition we can animate the selected tab bar.
   const HORIZONTAL_PADDING = 8;
   const AnimatedContext = React.createContext();
 
-  function AnimatedTabs({ color, ...rest }) {
+  function AnimatedTabs({ color, children, ...rest }) {
     // some state to store the position we want to animate to
     const [activeRect, setActiveRect] = useState(null);
+    const ref = useRef();
+    const rect = useRect(ref);
 
     return (
       // put the function to change the styles on context so an active Tab
       // can call it, then style it up
       <AnimatedContext.Provider value={setActiveRect}>
         {/* make sure to forward props since we're wrapping Tabs */}
-        <Tabs {...rest} style={{ ...rest.style, position: "relative" }} />
-        <div
-          style={{
-            position: "absolute",
-            height: 2,
-            background: color,
-            transition: "all 300ms ease",
-            left: activeRect && activeRect.left,
-            // subtract both sides of horizontal padding to center the div
-            width: activeRect && activeRect.width - HORIZONTAL_PADDING * 2,
-            top: activeRect && activeRect.bottom - 2,
-          }}
-        />
+        <Tabs
+          {...rest}
+          ref={ref}
+          style={{ ...rest.style, position: "relative" }}
+        >
+          <div
+            style={{
+              position: "absolute",
+              height: 2,
+              background: color,
+              transition: "all 300ms ease",
+              left:
+                (activeRect && activeRect.left) -
+                (rect && rect.left) +
+                HORIZONTAL_PADDING,
+              top: (activeRect && activeRect.bottom) - (rect && rect.top),
+              // subtract both sides of horizontal padding to center the div
+              width: activeRect && activeRect.width - HORIZONTAL_PADDING * 2,
+            }}
+          />
+          {children}
+        </Tabs>
       </AnimatedContext.Provider>
     );
   }


### PR DESCRIPTION
`useRect` is relative to viewport, but absolute positioning is relative to containing block. Compensate by using the difference.


Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)

## Before / after

![Screen Recording 2020-05-21 at 09 55 AM](https://user-images.githubusercontent.com/235886/82536781-49206880-9b49-11ea-9372-a351e5e41fac.gif)

![Screen Recording 2020-05-21 at 09 52 AM](https://user-images.githubusercontent.com/235886/82536787-4de51c80-9b49-11ea-8d75-81838bb6ed18.gif)
