### PR TITLE
Combobox: State machine rewrite

### DIFF
--- a/packages/combobox/__tests__/combobox.test.tsx
+++ b/packages/combobox/__tests__/combobox.test.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { render, withMarkup, userEvent, fireEvent } from "$test/utils";
+import { render, withMarkup, userEvent } from "$test/utils";
 import { AxeResults } from "$test/types";
 import { axe } from "jest-axe";
 import {
@@ -8,7 +8,6 @@ import {
   ComboboxList,
   ComboboxOption,
   ComboboxPopover,
-  ComboboxInputProps,
   useComboboxContext,
 } from "@reach/combobox";
 import matchSorter from "match-sorter";

--- a/packages/combobox/examples/persisted-selection.example.js
+++ b/packages/combobox/examples/persisted-selection.example.js
@@ -11,13 +11,13 @@ import { useThrottle } from "use-throttle";
 import cities from "./cities";
 import "@reach/combobox/styles.css";
 
-let name = "Basic";
+let name = "Persisted selection";
 
 function Example() {
   let [term, setTerm] = useState("");
   let results = useCityMatch(term);
 
-  const handleChange = event => {
+  const handleChange = (event) => {
     setTerm(event.target.value);
   };
 
@@ -31,7 +31,7 @@ function Example() {
             <p>
               <button>Hi</button>
             </p>
-            <ComboboxList>
+            <ComboboxList persistSelection>
               {results.slice(0, 10).map((result, index) => (
                 <ComboboxOption
                   key={index}
@@ -59,7 +59,7 @@ function useCityMatch(term) {
       term.trim() === ""
         ? null
         : matchSorter(cities, term, {
-            keys: [item => `${item.city}, ${item.state}`],
+            keys: [(item) => `${item.city}, ${item.state}`],
           }),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [throttledTerm]

--- a/packages/combobox/examples/with-button.example.js
+++ b/packages/combobox/examples/with-button.example.js
@@ -34,7 +34,7 @@ function Example() {
         </ComboboxButton>
         {results && (
           <ComboboxPopover>
-            <ComboboxList>
+            <ComboboxList persistSelection>
               {results.slice(0, 10).map((result, index) => (
                 <ComboboxOption
                   key={index}
@@ -62,7 +62,7 @@ function useCityMatch(term) {
       throttledTerm.trim() === ""
         ? null
         : matchSorter(cities, throttledTerm, {
-            keys: [item => `${item.city}, ${item.state}`],
+            keys: [(item) => `${item.city}, ${item.state}`],
           }),
     [throttledTerm]
   );

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@reach/auto-id": "^0.10.3",
     "@reach/descendants": "^0.10.3",
+    "@reach/machine": "^0.10.3",
     "@reach/popover": "^0.10.3",
     "@reach/portal": "^0.10.3",
     "@reach/utils": "^0.10.3",

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -34,6 +34,7 @@ import {
   getOwnerDocument,
   isFunction,
   makeId,
+  memoWithAs,
   useIsomorphicLayoutEffect,
   useForkedRef,
   useUpdateEffect,
@@ -387,7 +388,7 @@ if (__DEV__) {
   ComboboxInputImpl.displayName = "ComboboxInput";
 }
 
-export const ComboboxInput = React.memo(ComboboxInputImpl);
+export const ComboboxInput = memoWithAs(ComboboxInputImpl);
 
 /**
  * @see Docs https://reacttraining.com/reach-ui/combobox#comboboxinput-props

--- a/packages/combobox/src/machine.ts
+++ b/packages/combobox/src/machine.ts
@@ -248,7 +248,6 @@ export const createMachineDefinition = ({
           actions: [
             (ctx, event) => {
               if (event.type === ComboboxEvents.SelectWithKeyboard) {
-                console.log(ctx.navigationValue);
                 // don't want to submit forms
                 event.event.preventDefault();
                 event.navigationValue && event.onSelect(event.navigationValue);

--- a/packages/combobox/src/machine.ts
+++ b/packages/combobox/src/machine.ts
@@ -1,0 +1,355 @@
+import { assign, MachineEventWithRefs, StateMachine } from "@reach/machine";
+// import { getOwnerDocument } from "@reach/utils";
+import { ComboboxValue } from "./index";
+
+////////////////////////////////////////////////////////////////////////////////
+// States
+
+export enum ComboboxStates {
+  // Nothing going on, waiting for the user to type or use the arrow keys
+  Idle = "IDLE",
+  // The component is suggesting options as the user types
+  Suggesting = "SUGGESTING",
+  // The user is using the keyboard to navigate the list, not typing
+  Navigating = "NAVIGATING",
+  // The user is interacting with arbitrary elements inside the popup that
+  // are not ComboboxInputs
+  Interacting = "INTERACTING",
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Events
+
+export enum ComboboxEvents {
+  // User cleared the value w/ backspace, but input still has focus
+  Clear = "CLEAR",
+  // User is typing
+  Change = "CHANGE",
+  // Initial input value change handler for syncing user state with state
+  // machine. Prevents initial change from sending the user to the Navigating
+  // state.
+  InitialChange = "INITIAL_CHANGE",
+  // User is navigating w/ the keyboard
+  Navigate = "NAVIGATE",
+  // User can be navigating with keyboard and then click instead, we want the
+  // value from the click, not the current nav item
+  SelectWithKeyboard = "SELECT_WITH_KEYBOARD",
+  SelectWithClick = "SELECT_WITH_CLICK",
+  // Pretty self-explanatory, user can hit escape or blur to close the popover
+  Escape = "ESCAPE",
+  Blur = "BLUR",
+  // The user left the input to interact with arbitrary elements inside the
+  // popup
+  Interact = "INTERACT",
+  Focus = "FOCUS",
+  ClickButton = "CLICK_BUTTON",
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Actions and conditions
+
+const shouldOpenOnFocus = (ctx: ComboboxStateData, event: ComboboxEvent) => {
+  return event.type === ComboboxEvents.Focus && !!event.openOnFocus;
+};
+
+const clearNavigationValue = assign<ComboboxStateData, ComboboxEvent>({
+  navigationValue: null,
+});
+
+const clearValue = assign<ComboboxStateData, ComboboxEvent>({
+  value: "",
+});
+
+const setValue = assign<ComboboxStateData, any>({
+  value: (ctx, event) =>
+    typeof event.value !== "undefined" ? event.value : ctx.value,
+});
+
+const setNavigationValue = assign<ComboboxStateData, any>({
+  navigationValue: (_, event) => {
+    return event.value || null;
+  },
+});
+
+const setValueFromNavigationValue = assign<ComboboxStateData, any>({
+  value: (ctx) => ctx.navigationValue || null,
+});
+
+const setInitialNavigationValue = assign<ComboboxStateData, ComboboxEvent>({
+  navigationValue: (ctx, event) => {
+    if (
+      event.type === ComboboxEvents.Navigate ||
+      event.type === ComboboxEvents.ClickButton
+    ) {
+      return event.persistSelection ? ctx.value : null;
+    }
+    return null;
+  },
+});
+
+function focusInput(_: any, event: any) {
+  if (event.type !== ComboboxEvents.SelectWithClick) {
+    event.refs.input?.focus();
+  }
+}
+
+// TODO: Gross, make not gross maybe
+function focusInputAfterRaf(_: any, event: any) {
+  requestAnimationFrame(() => {
+    focusInput(_, event);
+  });
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+/**
+ * Initializer for our state machine.
+ *
+ * @param initial
+ * @param props
+ */
+export const createMachineDefinition = ({
+  value,
+}: {
+  value: ComboboxValue | null;
+}): StateMachine.Config<ComboboxStateData, ComboboxEvent, ComboboxState> => ({
+  id: "combobox",
+  initial: ComboboxStates.Idle,
+  context: {
+    // The value the user has typed. We derive this also when the developer is
+    // controlling the value of ComboboxInput.
+    value,
+    // options: [],
+    navigationValue: null,
+  },
+  states: {
+    [ComboboxStates.Idle]: {
+      on: {
+        [ComboboxEvents.Change]: {
+          target: ComboboxStates.Suggesting,
+          actions: [clearNavigationValue, setValue],
+        },
+        [ComboboxEvents.InitialChange]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue, setValue],
+        },
+        [ComboboxEvents.Blur]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+        [ComboboxEvents.Clear]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue, clearValue],
+        },
+        [ComboboxEvents.Focus]: [
+          {
+            target: ComboboxStates.Suggesting,
+            actions: [setNavigationValue],
+            cond: shouldOpenOnFocus,
+          },
+          {
+            target: ComboboxStates.Idle,
+          },
+        ],
+        [ComboboxEvents.Navigate]: {
+          target: ComboboxStates.Navigating,
+          actions: [setInitialNavigationValue, focusInput],
+        },
+        [ComboboxEvents.ClickButton]: {
+          target: ComboboxStates.Suggesting,
+          actions: [setInitialNavigationValue, focusInputAfterRaf],
+        },
+      },
+    },
+    [ComboboxStates.Suggesting]: {
+      on: {
+        [ComboboxEvents.Change]: {
+          target: ComboboxStates.Suggesting,
+          actions: [clearNavigationValue, setValue],
+        },
+        [ComboboxEvents.Focus]: [
+          {
+            target: ComboboxStates.Suggesting,
+            actions: [setNavigationValue],
+            cond: shouldOpenOnFocus,
+          },
+          {
+            target: ComboboxStates.Suggesting,
+          },
+        ],
+        [ComboboxEvents.Navigate]: {
+          target: ComboboxStates.Navigating,
+          actions: [setNavigationValue, focusInput],
+        },
+        [ComboboxEvents.Clear]: {
+          target: ComboboxStates.Idle,
+          actions: [clearValue, clearNavigationValue],
+        },
+        [ComboboxEvents.Escape]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue, focusInput],
+        },
+        [ComboboxEvents.Blur]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+        [ComboboxEvents.SelectWithClick]: {
+          target: ComboboxStates.Idle,
+          actions: [setValue, clearNavigationValue, focusInput],
+        },
+        [ComboboxEvents.Interact]: {
+          target: ComboboxStates.Interacting,
+        },
+        [ComboboxEvents.ClickButton]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+      },
+    },
+    [ComboboxStates.Navigating]: {
+      on: {
+        [ComboboxEvents.Change]: {
+          target: ComboboxStates.Suggesting,
+          actions: [clearNavigationValue, setValue],
+        },
+        [ComboboxEvents.Focus]: [
+          {
+            target: ComboboxStates.Suggesting,
+            actions: [setNavigationValue],
+            cond: shouldOpenOnFocus,
+          },
+          {
+            target: ComboboxStates.Navigating,
+          },
+        ],
+        [ComboboxEvents.Clear]: {
+          target: ComboboxStates.Idle,
+          actions: [clearValue, clearNavigationValue],
+        },
+        [ComboboxEvents.Blur]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+        [ComboboxEvents.Escape]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue, focusInput],
+        },
+        [ComboboxEvents.Navigate]: {
+          target: ComboboxStates.Navigating,
+          actions: [setNavigationValue, focusInput],
+        },
+        [ComboboxEvents.SelectWithClick]: {
+          target: ComboboxStates.Idle,
+          actions: [setValue, clearNavigationValue, focusInput],
+        },
+        [ComboboxEvents.SelectWithKeyboard]: {
+          target: ComboboxStates.Idle,
+          actions: [setValueFromNavigationValue, clearNavigationValue],
+        },
+        [ComboboxEvents.ClickButton]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+        [ComboboxEvents.Interact]: {
+          target: ComboboxStates.Interacting,
+        },
+      },
+    },
+    [ComboboxStates.Interacting]: {
+      on: {
+        [ComboboxEvents.Change]: {
+          target: ComboboxStates.Suggesting,
+          actions: [clearNavigationValue, setValue],
+        },
+        [ComboboxEvents.Clear]: {
+          target: ComboboxStates.Idle,
+          actions: [clearValue, clearNavigationValue],
+        },
+        [ComboboxEvents.Focus]: [
+          {
+            target: ComboboxStates.Suggesting,
+            actions: [setNavigationValue],
+            cond: shouldOpenOnFocus,
+          },
+          {
+            target: ComboboxStates.Interacting,
+          },
+        ],
+        [ComboboxEvents.Blur]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+        [ComboboxEvents.Escape]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue, focusInput],
+        },
+        [ComboboxEvents.Navigate]: {
+          target: ComboboxStates.Navigating,
+          actions: [setNavigationValue, focusInput],
+        },
+        [ComboboxEvents.ClickButton]: {
+          target: ComboboxStates.Idle,
+          actions: [clearNavigationValue],
+        },
+        [ComboboxEvents.SelectWithClick]: {
+          target: ComboboxStates.Idle,
+          actions: [setValue, clearNavigationValue, focusInput],
+        },
+      },
+    },
+  },
+});
+
+/**
+ * State object for the state machine.
+ */
+export type ComboboxState = {
+  value: ComboboxStates;
+  context: ComboboxStateData;
+};
+
+////////////////////////////////////////////////////////////////////////////////
+// Types
+
+export type ComboboxStateData = {
+  navigationValue?: string | null;
+  value?: string | null;
+};
+
+/**
+ * Shared partial interface for all of our event objects.
+ */
+export interface ComboboxEventBase extends MachineEventWithRefs {
+  refs: ComboboxNodeRefs;
+}
+
+/**
+ * DOM nodes for all of the refs used in the  state machine.
+ */
+export type ComboboxNodeRefs = {
+  input: HTMLInputElement | null;
+};
+
+export type ComboboxEvent = ComboboxEventBase &
+  (
+    | { type: ComboboxEvents.Blur }
+    | { type: ComboboxEvents.Change; value: ComboboxValue }
+    | { type: ComboboxEvents.InitialChange; value: ComboboxValue }
+    | { type: ComboboxEvents.Clear }
+    | { type: ComboboxEvents.Escape }
+    | { type: ComboboxEvents.Focus; openOnFocus?: boolean }
+    | { type: ComboboxEvents.Interact }
+    | {
+        type: ComboboxEvents.Navigate;
+        persistSelection?: boolean;
+        value?: ComboboxValue | null;
+      }
+    | { type: ComboboxEvents.ClickButton; persistSelection?: boolean }
+    | {
+        type: ComboboxEvents.SelectWithClick;
+        value: ComboboxValue;
+      }
+    | {
+        type: ComboboxEvents.SelectWithKeyboard;
+      }
+  );

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -208,7 +208,7 @@ export function forwardRefWithAs<Props, ComponentType extends As = "div">(
   comp: (
     props: PropsFromAs<ComponentType, Props>,
     ref: React.RefObject<any>
-  ) => React.ReactElement<Props, ComponentType> | null
+  ) => React.ReactElement
 ) {
   return (React.forwardRef(comp as any) as unknown) as ComponentWithAs<
     ComponentType,

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -208,7 +208,7 @@ export function forwardRefWithAs<Props, ComponentType extends As = "div">(
   comp: (
     props: PropsFromAs<ComponentType, Props>,
     ref: React.RefObject<any>
-  ) => React.ReactElement
+  ) => React.ReactElement | null
 ) {
   return (React.forwardRef(comp as any) as unknown) as ComponentWithAs<
     ComponentType,

--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -202,18 +202,29 @@ export function createNamedContext<ContextValueType>(
  * TODO: Eventually we should probably just try to get the type defs above
  * working across the board, but ain't nobody got time for that mess!
  *
- * @param Comp
+ * @param comp
  */
 export function forwardRefWithAs<Props, ComponentType extends As = "div">(
   comp: (
     props: PropsFromAs<ComponentType, Props>,
     ref: React.RefObject<any>
-  ) => React.ReactElement | null
+  ) => React.ReactElement<Props, ComponentType> | null
 ) {
   return (React.forwardRef(comp as any) as unknown) as ComponentWithAs<
     ComponentType,
     Props
   >;
+}
+
+/**
+ * Same deal as above
+ *
+ * @param comp
+ */
+export function memoWithAs<Props, ComponentType extends As = "div">(
+  comp: ComponentWithAs<ComponentType, Props>
+) {
+  return React.memo(comp) as ComponentWithAs<ComponentType, Props>;
 }
 
 /**


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

We're using real state machines these days, so I am updating some of our older components to follow similar patterns. Found and fixed a few edge cases in the process. Combobox logic is mostly unchanged but I was able to move more logic over to the state machine than was allowed with the transition/reducer setup.

**NOTE:** Not yet ready to merge!