### PR TITLE
[menu-button] Dont try to use .relatedTarget of the mousedown event

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -857,15 +857,9 @@ export const MenuPopover = forwardRef<any, MenuPopoverProps>(
         if (buttonClickedRef.current) {
           buttonClickedRef.current = false;
         } else {
-          let { relatedTarget, target } = event;
-
           // We on want to close only if focus rests outside the menu
           if (isExpanded && popoverRef.current) {
-            if (
-              !popoverRef.current?.contains(
-                (relatedTarget || target) as Element
-              )
-            ) {
+            if (!popoverRef.current.contains(event.target as Element)) {
               dispatch({ type: CLOSE_MENU, payload: { buttonRef } });
             }
           }


### PR DESCRIPTION
As far as I know `.relatedTarget` is always null for mousedown events and the spec seems to confirm that:
https://w3c.github.io/uievents/#event-type-mousedown

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other
