### PR TITLE
[popover] Fix stuck focus

### DIFF
--- a/packages/popover/src/index.tsx
+++ b/packages/popover/src/index.tsx
@@ -241,7 +241,11 @@ function useSimulateTabNavigationForReactTree<
       elements && triggerRef.current
         ? elements.indexOf(triggerRef.current)
         : -1;
-    return elements && elements[targetIndex + 1];
+    const elementAfterTrigger = elements && elements[targetIndex + 1];
+    return popoverRef.current &&
+      popoverRef.current.contains(elementAfterTrigger || null)
+      ? false
+      : elementAfterTrigger;
   }
 
   function tabbedFromTriggerToPopover() {


### PR DESCRIPTION
When the `targetRef` is the last tabbable element outside the popover, `getElementAfterTrigger` returns the first tabbable element inside the portal causing the focus to stay trapped inside the popover. What we want is for `getElementAfterTrigger` to return an element only if it is not inside the popover.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
