### PR TITLE
test(menu-button): add regression test for closing menu on selection

### DIFF
--- a/packages/menu-button/__tests__/menu-button.test.tsx
+++ b/packages/menu-button/__tests__/menu-button.test.tsx
@@ -168,5 +168,37 @@ describe("<MenuButton />", () => {
       fireEvent.click(getByTestId("input"));
       expect(getByRole("button")).not.toHaveFocus();
     });
+
+    it("should open and close on selection", () => {
+      const onSelect = jest.fn();
+      const { getByText, getByTestId } = render(
+        <Menu>
+          <MenuButton>MenuButton</MenuButton>
+          <MenuList data-testid="menu-test-id">
+            <MenuItem onSelect={onSelect}>First</MenuItem>
+            <MenuItem onSelect={onSelect}>Second</MenuItem>
+            <MenuItem onSelect={onSelect}>Third</MenuItem>
+          </MenuList>
+        </Menu>
+      );
+
+      const menu = getByTestId("menu-test-id");
+      expect(menu).not.toBeVisible();
+
+      const button = getByText("MenuButton");
+      click(button);
+      expect(menu).toBeVisible();
+
+      const item = getByText("First");
+      click(item);
+      expect(onSelect).toHaveBeenCalled();
+      expect(menu).not.toBeVisible();
+    });
   });
 });
+
+function click(element: HTMLElement) {
+  fireEvent.mouseDown(element);
+  fireEvent.mouseUp(element);
+  fireEvent.click(element);
+}


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other

<hr />

I noticed that this test in my code-base started failing after updating the menu button to `v0.10.5` from `v0.10.3`. 

I've added said test to this PR to demonstrate the issue. I think it is related to https://github.com/reach/reach-ui/commit/dae686dfd3943f70087195115b97ca50e81e97f9.

Let's try to fix it in this PR? @chancestrickland 