### PR TITLE
@reach/tabs: Fix wrap of blur event in Tab component

### DIFF
--- a/packages/tabs/__tests__/tabs.test.tsx
+++ b/packages/tabs/__tests__/tabs.test.tsx
@@ -531,5 +531,43 @@ describe("<Tabs />", () => {
       // fireEvent.keyDown(tabList, { key: "ArrowRight", code: 39 });
       // expect(getByText("Tab 2")).toHaveFocus();
     });
+
+    it("correctly calls focus and blur events on Tab component", () => {
+      const onBlur = jest.fn();
+      const onFocus = jest.fn();
+
+      const { getAllByRole } = render(
+        <Tabs>
+          <TabList>
+            <Tab onFocus={onFocus} onBlur={onBlur}>
+              Tab 1
+            </Tab>
+            <Tab onFocus={onFocus} onBlur={onBlur}>
+              Tab 2
+            </Tab>
+          </TabList>
+          <TabPanels>
+            <TabPanel>
+              <p>Panel 1</p>
+            </TabPanel>
+            <TabPanel>
+              <p>Panel 2</p>
+            </TabPanel>
+          </TabPanels>
+        </Tabs>
+      );
+
+      let tabs = getAllByRole("tab");
+
+      fireEvent.focus(tabs[0]);
+
+      expect(onFocus).toHaveBeenCalledTimes(1);
+
+      fireEvent.blur(tabs[0]);
+      fireEvent.focus(tabs[1]);
+
+      expect(onFocus).toHaveBeenCalledTimes(2);
+      expect(onBlur).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/packages/tabs/src/index.tsx
+++ b/packages/tabs/src/index.tsx
@@ -485,7 +485,7 @@ export const Tab = forwardRefWithAs<
   );
 
   let handleBlur = useEventCallback(
-    wrapEvent(onFocus, () => {
+    wrapEvent(onBlur, () => {
       setFocusedIndex(-1);
     })
   );


### PR DESCRIPTION
This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other