### PR TITLE
[website] fix typo in anchor link for `useAccordionItemContext`

### DIFF
--- a/website/src/pages/accordion.mdx
+++ b/website/src/pages/accordion.mdx
@@ -12,7 +12,7 @@ import { TOC, TOCList, TOCLink } from "../components/TOC";
     <TOCLink href="#accordionbutton">AccordionButton</TOCLink>
     <TOCLink href="#accordionpanel">AccordionPanel</TOCLink>
     <TOCLink href="#useaccordioncontext">useAccordionContext</TOCLink>
-    <TOCLink href="#useAccordionitemcontext">useAccordionItemContext</TOCLink>
+    <TOCLink href="#useaccordionitemcontext">useAccordionItemContext</TOCLink>
   </TOCList>
 </TOC>
 


### PR DESCRIPTION
Just a small typo I found which is causing a link to break. The ID in the anchor should be all lowercase.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other