### PR TITLE
@reach/tooltip: Export `positionTooltip` function

### DIFF
--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -490,7 +490,7 @@ const TooltipContent = forwardRefWithAs<TooltipContentProps, "div">(
       id,
       isVisible,
       label,
-      position = positionDefault,
+      position = positionTooltip,
       style,
       triggerRect,
       ...props
@@ -549,9 +549,6 @@ if (__DEV__) {
 
 ////////////////////////////////////////////////////////////////////////////////
 
-// feels awkward when it's perfectly aligned w/ the trigger
-const OFFSET = 8;
-
 function getStyles(
   position: Position,
   triggerRect: PRect,
@@ -564,7 +561,12 @@ function getStyles(
   return position(triggerRect, tooltipRect);
 }
 
-let positionDefault: Position = (triggerRect, tooltipRect) => {
+// Default offset from the trigger (e.g., if the tooltip is positioned above,
+// there will be 8px between the bottom of the tooltip and the top of the trigger).
+// It feels awkward when it's perfectly aligned w/ the trigger
+const OFFSET_DEFAULT = 8;
+
+export const positionTooltip: Position = (triggerRect, tooltipRect, offset = OFFSET_DEFAULT) => {
   let { width: windowWidth, height: windowHeight } = getDocumentDimensions();
   if (!triggerRect || !tooltipRect) {
     return {};
@@ -573,7 +575,7 @@ let positionDefault: Position = (triggerRect, tooltipRect) => {
   let collisions = {
     top: triggerRect.top - tooltipRect.height < 0,
     right: windowWidth < triggerRect.left + tooltipRect.width,
-    bottom: windowHeight < triggerRect.bottom + tooltipRect.height + OFFSET,
+    bottom: windowHeight < triggerRect.bottom + tooltipRect.height + offset,
     left: triggerRect.left - tooltipRect.width < 0,
   };
 
@@ -586,10 +588,10 @@ let positionDefault: Position = (triggerRect, tooltipRect) => {
       : `${triggerRect.left + window.pageXOffset}px`,
     top: directionUp
       ? `${
-          triggerRect.top - OFFSET - tooltipRect.height + window.pageYOffset
+          triggerRect.top - offset - tooltipRect.height + window.pageYOffset
         }px`
       : `${
-          triggerRect.top + OFFSET + triggerRect.height + window.pageYOffset
+          triggerRect.top + offset + triggerRect.height + window.pageYOffset
         }px`,
   };
 };


### PR DESCRIPTION
This allows users to re-use this logic in their own apps.

In particular, I had a use case where I wanted to change the tooltip offset and the only way I could do so was to copy the definition of the `positionDefault` function.

**Note:** I didn't test this (this PR was made from the web interface), just curious if this is something that would be acceptable. Alternatively (and/or additionally), we could add an `offset` prop to the `Tooltip` component.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other
