### PR TITLE
tabs: Fix prop-types for `Tabs` children

### DIFF
--- a/packages/tabs/src/index.tsx
+++ b/packages/tabs/src/index.tsx
@@ -273,7 +273,7 @@ export type TabsProps = {
 if (__DEV__) {
   Tabs.displayName = "Tabs";
   Tabs.propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.oneOfType([PropTypes.func, PropTypes.node]).isRequired,
     onChange: PropTypes.func,
     orientation: PropTypes.oneOf(Object.values(TabsOrientation)),
     index: (props, name, compName, location, propName) => {


### PR DESCRIPTION
This is a bug fix. https://reach.tech/tabs#tabs-children mentions that using a function for children is supported.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
