### PR TITLE
Reduce slider padding

### DIFF
--- a/packages/slider/styles.css
+++ b/packages/slider/styles.css
@@ -6,8 +6,8 @@
   width: 350px;
   max-width: 100%;
   height: 4px;
-  padding-top: 30px;
-  padding-bottom: 30px;
+  padding-top: 4px;
+  padding-bottom: 8px;
 }
 
 [data-reach-slider-input][data-orientation="vertical"] {
@@ -15,8 +15,8 @@
   height: 250px;
   max-height: 100%;
   max-width: calc(100% - 60%);
-  padding-left: 30px;
-  padding-right: 30px;
+  padding-left: 4px;
+  padding-right: 8px;
 }
 
 [data-reach-slider-input][data-disabled] {


### PR DESCRIPTION
The default styling adds a ton of extraneous spacing to the slider, which is especially pronounced when adding a label (which one should always do).

Before:
![image](https://user-images.githubusercontent.com/14965732/94038789-8497a180-fd8c-11ea-8151-16ed44547f2a.png)

After:
![image](https://user-images.githubusercontent.com/14965732/94038873-a55ff700-fd8c-11ea-9558-96872be9bba7.png)

With 22px of top and bottom margin, the touch target is still 44px, which is in line with UX and accessibility guidelines, but without the extra padding, which most users of this component are going to have to override.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [X] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
