### PR TITLE
Remove slider width styling

### DIFF
--- a/packages/slider/styles.css
+++ b/packages/slider/styles.css
@@ -3,7 +3,6 @@
 }
 
 [data-reach-slider-input][data-orientation="horizontal"] {
-  width: 350px;
   max-width: 100%;
   height: 4px;
   padding-top: 30px;


### PR DESCRIPTION
Setting the slider to have a width of 350px seems really arbitrary and is almost never what you want. Typically, inputs default to taking up the full width of a container and I don't see why a slider should be any different.

AFAIK the styling that reach-ui ships with is the minimum to make the component functional, and this css rule seems to go against that.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [X] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
