### PR TITLE
Add react v17 to peerDeps

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -19,8 +19,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/accordion.esm.js",

--- a/packages/alert-dialog/package.json
+++ b/packages/alert-dialog/package.json
@@ -21,8 +21,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/alert-dialog.esm.js",

--- a/packages/alert/package.json
+++ b/packages/alert/package.json
@@ -19,8 +19,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/alert.esm.js",

--- a/packages/auto-id/package.json
+++ b/packages/auto-id/package.json
@@ -13,8 +13,8 @@
     "build": "ts-node --transpile-only ../../scripts/build-package $npm_package_name"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/auto-id.esm.js",

--- a/packages/checkbox/package.json
+++ b/packages/checkbox/package.json
@@ -20,8 +20,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/checkbox.esm.js",

--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -23,8 +23,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/combobox.esm.js",

--- a/packages/component-component/package.json
+++ b/packages/component-component/package.json
@@ -16,8 +16,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.4.0",
-    "react-dom": "^16.4.0"
+    "react": "^16.4.0 || ^17.0.0",
+    "react-dom": "^16.4.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/component-component.esm.js",

--- a/packages/descendants/package.json
+++ b/packages/descendants/package.json
@@ -17,8 +17,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/descendants.esm.js",

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -21,8 +21,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/dialog.esm.js",

--- a/packages/disclosure/package.json
+++ b/packages/disclosure/package.json
@@ -18,8 +18,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/disclosure.esm.js",

--- a/packages/listbox/package.json
+++ b/packages/listbox/package.json
@@ -21,8 +21,8 @@
     "prop-types": "^15.7.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/listbox.esm.js",

--- a/packages/machine/package.json
+++ b/packages/machine/package.json
@@ -18,8 +18,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/machine.esm.js",

--- a/packages/menu-button/package.json
+++ b/packages/menu-button/package.json
@@ -21,8 +21,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/menu-button.esm.js",

--- a/packages/popover/package.json
+++ b/packages/popover/package.json
@@ -20,8 +20,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/popover.esm.js",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -13,8 +13,8 @@
     "build": "ts-node --transpile-only ../../scripts/build-package $npm_package_name"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/portal.esm.js",

--- a/packages/rect/package.json
+++ b/packages/rect/package.json
@@ -19,8 +19,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/rect.esm.js",

--- a/packages/skip-nav/package.json
+++ b/packages/skip-nav/package.json
@@ -17,8 +17,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/skip-nav.esm.js",

--- a/packages/slider/package.json
+++ b/packages/slider/package.json
@@ -19,8 +19,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.9.0",
-    "react-dom": "^16.9.0"
+    "react": "^16.9.0 || ^17.0.0",
+    "react-dom": "^16.9.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/slider.esm.js",

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -20,8 +20,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/tabs.esm.js",

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -22,8 +22,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/tooltip.esm.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -13,8 +13,8 @@
     "build": "ts-node --transpile-only ../../scripts/build-package $npm_package_name"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/utils.esm.js",

--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -13,8 +13,8 @@
     "build": "ts-node --transpile-only ../../scripts/build-package $npm_package_name"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/visually-hidden.esm.js",

--- a/packages/window-size/package.json
+++ b/packages/window-size/package.json
@@ -18,8 +18,8 @@
     "tslib": "^2.0.0"
   },
   "peerDependencies": {
-    "react": "^16.8.0",
-    "react-dom": "^16.8.0"
+    "react": "^16.8.0 || ^17.0.0",
+    "react-dom": "^16.8.0 || ^17.0.0"
   },
   "main": "dist/index.js",
   "module": "dist/window-size.esm.js",


### PR DESCRIPTION
This Pull Request adds React v17 to the peerDependencies of all packages. This will allow you to use `@reach/*` in our products using React v17.

---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
