### PR TITLE
[Utils] export imported types as types

### DIFF
--- a/packages/utils/src/index.tsx
+++ b/packages/utils/src/index.tsx
@@ -742,7 +742,7 @@ export function wrapEvent<EventType extends React.SyntheticEvent | Event>(
 }
 
 // Export types
-export {
+export type {
   As,
   AssignableRef,
   ComponentWithAs,


### PR DESCRIPTION
Fixes: https://github.com/reach/reach-ui/issues/707
