### PR TITLE
fix(tooltip): consistent cross-browser behavior with disabled elements

### DIFF
--- a/packages/tooltip/examples/with-disabled-button.example.js
+++ b/packages/tooltip/examples/with-disabled-button.example.js
@@ -9,7 +9,17 @@ function Example() {
     <div>
       <Tooltip label="Oh oh oh, oh oh">
         <button style={{ fontSize: 25, pointerEvents: "all" }} disabled>
-          Can't Touch This
+          <span aria-hidden>💾</span> Can't Touch This
+        </button>
+      </Tooltip>
+      <Tooltip label="Oh oh oh, oh oh">
+        <button style={{ fontSize: 25, pointerEvents: "all" }} disabled>
+          <span aria-hidden>🔔</span>
+        </button>
+      </Tooltip>
+      <Tooltip label="Oh oh oh, oh oh">
+        <button style={{ fontSize: 25, pointerEvents: "all" }} disabled>
+          <span aria-hidden>⚙️</span>
         </button>
       </Tooltip>
     </div>

--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -61,6 +61,7 @@ import PropTypes from "prop-types";
 
 const MOUSE_REST_TIMEOUT = 100;
 const LEAVE_TIMEOUT = 500;
+const POINTER_TYPE_MOUSE = "mouse";
 
 ////////////////////////////////////////////////////////////////////////////////
 // States
@@ -227,13 +228,17 @@ function clearContextId() {
  */
 function useTooltip<T extends HTMLElement>({
   id: idProp,
+  onPointerEnter,
+  onPointerMove,
+  onPointerLeave,
+  onPointerDown,
   onMouseEnter,
   onMouseMove,
   onMouseLeave,
+  onMouseDown,
   onFocus,
   onBlur,
   onKeyDown,
-  onMouseDown,
   ref: forwardedRef,
   DEBUG_STYLE,
 }: {
@@ -285,12 +290,73 @@ function useTooltip<T extends HTMLElement>({
     return () => ownerDocument.removeEventListener("keydown", listener);
   }, []);
 
+  React.useEffect(() => {
+    /*
+      This is a workaround for using tooltips with disabled controls in Safari.
+      Safari fires `pointerenter` but does not fire `pointerleave`
+      and `onPointerEventLeave` added to the trigger element will not work
+    */
+
+    if (!("PointerEvent" in window)) return;
+
+    let ownerDocument = getOwnerDocument(ownRef.current)!;
+
+    function listener(event: MouseEvent) {
+      // @ts-ignore `disabled` does not exist on HTMLDivElement but tooltips can be used with different elements
+      if (state !== VISIBLE || !ownRef.current?.disabled) return;
+
+      let target = event.target as Element | null;
+      if (
+        (target?.hasAttribute("data-reach-tooltip-trigger") &&
+          target?.hasAttribute("aria-describedby")) ||
+        target?.closest("[data-reach-tooltip-trigger][aria-describedby]")
+      ) {
+        return;
+      }
+
+      transition(GLOBAL_MOUSE_MOVE);
+    }
+
+    ownerDocument.addEventListener("mousemove", listener);
+    return () => ownerDocument.removeEventListener("mousemove", listener);
+  }, []);
+
+  function wrapMouseEvent<EventType extends React.SyntheticEvent | Event>(
+    theirHandler: ((event: EventType) => any) | undefined,
+    ourHandler: (event: EventType) => any
+  ) {
+    // Use internal MouseEvent handler only if PointerEvent not supported
+    if ("PointerEvent" in window) return theirHandler;
+
+    return wrapEvent(theirHandler, ourHandler);
+  }
+
+  function wrapPointerEventHandler(
+    handler: (event: React.PointerEvent) => any
+  ) {
+    return function onPointerEvent(event: React.PointerEvent) {
+      // Handle pointer events only from mouse device
+      if (event.pointerType !== POINTER_TYPE_MOUSE) return;
+      handler(event);
+    };
+  }
+
   function handleMouseEnter() {
     transition(MOUSE_ENTER, { id });
   }
 
   function handleMouseMove() {
     transition(MOUSE_MOVE, { id });
+  }
+
+  function handleMouseLeave() {
+    transition(MOUSE_LEAVE);
+  }
+
+  function handleMouseDown() {
+    // Allow quick click from one tool to another
+    if (context.id !== id) return;
+    transition(MOUSE_DOWN);
   }
 
   function handleFocus() {
@@ -301,20 +367,10 @@ function useTooltip<T extends HTMLElement>({
     transition(FOCUS, { id });
   }
 
-  function handleMouseLeave() {
-    transition(MOUSE_LEAVE);
-  }
-
   function handleBlur() {
     // Allow quick click from one tool to another
     if (context.id !== id) return;
     transition(BLUR);
-  }
-
-  function handleMouseDown() {
-    // Allow quick click from one tool to another
-    if (context.id !== id) return;
-    transition(MOUSE_DOWN);
   }
 
   function handleKeyDown(event: React.KeyboardEvent<T>) {
@@ -330,13 +386,29 @@ function useTooltip<T extends HTMLElement>({
     "aria-describedby": isVisible ? makeId("tooltip", id) : undefined,
     "data-reach-tooltip-trigger": "",
     ref,
-    onMouseEnter: wrapEvent(onMouseEnter, handleMouseEnter),
-    onMouseMove: wrapEvent(onMouseMove, handleMouseMove),
+    onPointerEnter: wrapEvent(
+      onPointerEnter,
+      wrapPointerEventHandler(handleMouseEnter)
+    ),
+    onPointerMove: wrapEvent(
+      onPointerMove,
+      wrapPointerEventHandler(handleMouseMove)
+    ),
+    onPointerLeave: wrapEvent(
+      onPointerLeave,
+      wrapPointerEventHandler(handleMouseLeave)
+    ),
+    onPointerDown: wrapEvent(
+      onPointerDown,
+      wrapPointerEventHandler(handleMouseDown)
+    ),
+    onMouseEnter: wrapMouseEvent(onMouseEnter, handleMouseEnter),
+    onMouseMove: wrapMouseEvent(onMouseMove, handleMouseMove),
+    onMouseLeave: wrapMouseEvent(onMouseLeave, handleMouseLeave),
+    onMouseDown: wrapMouseEvent(onMouseDown, handleMouseDown),
     onFocus: wrapEvent(onFocus, handleFocus),
     onBlur: wrapEvent(onBlur, handleBlur),
-    onMouseLeave: wrapEvent(onMouseLeave, handleMouseLeave),
     onKeyDown: wrapEvent(onKeyDown, handleKeyDown),
-    onMouseDown: wrapEvent(onMouseDown, handleMouseDown),
   };
 
   let tooltip: TooltipParams = {
@@ -378,13 +450,17 @@ const Tooltip = forwardRefWithAs<TooltipProps, "div">(function (
   // to make sure users can maintain control over the trigger's ref and events
   let [trigger, tooltip] = useTooltip({
     id,
+    onPointerEnter: child.props.onPointerEnter,
+    onPointerMove: child.props.onPointerMove,
+    onPointerLeave: child.props.onPointerLeave,
+    onPointerDown: child.props.onPointerDown,
     onMouseEnter: child.props.onMouseEnter,
     onMouseMove: child.props.onMouseMove,
     onMouseLeave: child.props.onMouseLeave,
+    onMouseDown: child.props.onMouseDown,
     onFocus: child.props.onFocus,
     onBlur: child.props.onBlur,
     onKeyDown: child.props.onKeyDown,
-    onMouseDown: child.props.onMouseDown,
     ref: child.ref,
     DEBUG_STYLE,
   });
@@ -557,7 +633,11 @@ function getStyles(
 // It feels awkward when it's perfectly aligned w/ the trigger
 const OFFSET_DEFAULT = 8;
 
-export const positionTooltip: Position = (triggerRect, tooltipRect, offset = OFFSET_DEFAULT) => {
+export const positionTooltip: Position = (
+  triggerRect,
+  tooltipRect,
+  offset = OFFSET_DEFAULT
+) => {
   let { width: windowWidth, height: windowHeight } = getDocumentDimensions();
   if (!triggerRect || !tooltipRect) {
     return {};
@@ -605,7 +685,7 @@ const transition: Transition = (event, payload) => {
 
   // Really useful for debugging
   // console.log({ event, state, nextState, contextId: context.id });
-  // !nextState && console.log('no transition taken')
+  // !nextState && console.log("no transition taken");
 
   if (!nextState) {
     return;
@@ -635,13 +715,17 @@ interface TriggerParams {
   "aria-describedby"?: string | undefined;
   "data-reach-tooltip-trigger": string;
   ref: React.Ref<any>;
-  onMouseEnter: React.ReactEventHandler;
-  onMouseMove: React.ReactEventHandler;
+  onPointerEnter: React.ReactEventHandler;
+  onPointerDown: React.ReactEventHandler;
+  onPointerMove: React.ReactEventHandler;
+  onPointerLeave: React.ReactEventHandler;
+  onMouseEnter?: React.ReactEventHandler;
+  onMouseDown?: React.ReactEventHandler;
+  onMouseMove?: React.ReactEventHandler;
+  onMouseLeave?: React.ReactEventHandler;
   onFocus: React.ReactEventHandler;
   onBlur: React.ReactEventHandler;
-  onMouseLeave: React.ReactEventHandler;
   onKeyDown: React.ReactEventHandler;
-  onMouseDown: React.ReactEventHandler;
 }
 
 interface TooltipParams {

--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -239,10 +239,12 @@ function useTooltip<T extends HTMLElement>({
   onFocus,
   onBlur,
   onKeyDown,
+  disabled,
   ref: forwardedRef,
   DEBUG_STYLE,
 }: {
   ref?: React.Ref<any>;
+  disabled?: boolean;
   DEBUG_STYLE?: boolean;
 } & React.HTMLAttributes<T> = {}): [TriggerParams, TooltipParams, boolean] {
   let id = String(useId(idProp));
@@ -296,14 +298,12 @@ function useTooltip<T extends HTMLElement>({
       Safari fires `pointerenter` but does not fire `pointerleave`
       and `onPointerEventLeave` added to the trigger element will not work
     */
-
-    if (!("PointerEvent" in window)) return;
+    if (!("PointerEvent" in window) || !disabled) return;
 
     let ownerDocument = getOwnerDocument(ownRef.current)!;
 
     function listener(event: MouseEvent) {
-      // @ts-ignore `disabled` does not exist on HTMLDivElement but tooltips can be used with different elements
-      if (state !== VISIBLE || !ownRef.current?.disabled) return;
+      if (state !== VISIBLE) return;
 
       if (
         event.target instanceof Element &&
@@ -319,7 +319,7 @@ function useTooltip<T extends HTMLElement>({
 
     ownerDocument.addEventListener("mousemove", listener);
     return () => ownerDocument.removeEventListener("mousemove", listener);
-  }, []);
+  }, [disabled]);
 
   function wrapMouseEvent<EventType extends React.SyntheticEvent | Event>(
     theirHandler: ((event: EventType) => any) | undefined,
@@ -462,6 +462,7 @@ const Tooltip = forwardRefWithAs<TooltipProps, "div">(function (
     onFocus: child.props.onFocus,
     onBlur: child.props.onBlur,
     onKeyDown: child.props.onKeyDown,
+    disabled: child.props.disabled,
     ref: child.ref,
     DEBUG_STYLE,
   });

--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -305,11 +305,11 @@ function useTooltip<T extends HTMLElement>({
       // @ts-ignore `disabled` does not exist on HTMLDivElement but tooltips can be used with different elements
       if (state !== VISIBLE || !ownRef.current?.disabled) return;
 
-      let target = event.target as Element | null;
       if (
-        (target?.hasAttribute("data-reach-tooltip-trigger") &&
-          target?.hasAttribute("aria-describedby")) ||
-        target?.closest("[data-reach-tooltip-trigger][aria-describedby]")
+        event.target instanceof Element &&
+        event.target.closest(
+          "[data-reach-tooltip-trigger][data-state='tooltip-visible']"
+        )
       ) {
         return;
       }
@@ -384,6 +384,7 @@ function useTooltip<T extends HTMLElement>({
     // `aria-describedby`.
     // https://www.w3.org/TR/wai-aria-practices-1.2/#tooltip
     "aria-describedby": isVisible ? makeId("tooltip", id) : undefined,
+    "data-state": isVisible ? "tooltip-visible" : "tooltip-hidden",
     "data-reach-tooltip-trigger": "",
     ref,
     onPointerEnter: wrapEvent(
@@ -713,6 +714,7 @@ const transition: Transition = (event, payload) => {
 
 interface TriggerParams {
   "aria-describedby"?: string | undefined;
+  "data-state": string;
   "data-reach-tooltip-trigger": string;
   ref: React.Ref<any>;
   onPointerEnter: React.ReactEventHandler;


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

----

Thanks for the great library!

This PR fixes https://github.com/reach/reach-ui/issues/231 and https://github.com/reach/reach-ui/issues/564

We use `@reach/tooltip` with disabled buttons and inputs and the need to create a wrapper around such components is rather inconvenient.

Pointer events API is [widely supported](https://caniuse.com/pointer) and PR contains a fallback just in case. 

Unfortunately couldn't update component tests because there is no support in `jsdom` yet https://github.com/jsdom/jsdom/pull/2666, I tried to use the proposed workarounds but they didn't work for me.  So tests actually check that component still works if there is no pointer events support.

It seems that Safari has incorrect implementation and triggers only `onPointerEnter` so I added a workaround for that. Checked on BrowserStack in IE11, Edge, Firefox, Chrome, and mobile Safari/Chrome and didn't notice a negative impact from that workaround.
