### PR TITLE
[Combobox] Update openOnFocus example to work even with empty input

### DIFF
--- a/packages/combobox/examples/open-on-focus.example.js
+++ b/packages/combobox/examples/open-on-focus.example.js
@@ -6,16 +6,13 @@ import {
   ComboboxOption,
   ComboboxPopover,
 } from "@reach/combobox";
-import { useCityMatch } from "./utils";
 import "@reach/combobox/styles.css";
 
 let name = "Open on focus";
 
 function Example() {
-  let [term, setTerm] = React.useState("D");
+  let [term, setTerm] = React.useState("");
   let [selection, setSelection] = React.useState("");
-  let results = useCityMatch(term);
-  let inputRef = React.useRef(null);
 
   function handleChange(event) {
     setTerm(event.target.value);
@@ -35,23 +32,16 @@ function Example() {
           onChange={handleChange}
           value={term}
           style={inputStyle}
-          ref={inputRef}
         />
-        {results && (
-          <ComboboxPopover style={popupStyle}>
-            <p>
-              <button>Hi</button>
-            </p>
-            <ComboboxList>
-              {results.slice(0, 10).map((result, index) => (
-                <ComboboxOption
-                  key={index}
-                  value={`${result.city}, ${result.state}`}
-                />
-              ))}
-            </ComboboxList>
-          </ComboboxPopover>
-        )}
+        <ComboboxPopover style={popupStyle}>
+          <ComboboxList>
+            <ComboboxOption value="Apple" />
+            <ComboboxOption value="Banana" />
+            <ComboboxOption value="Orange" />
+            <ComboboxOption value="Pineapple" />
+            <ComboboxOption value="Kiwi" />
+          </ComboboxList>
+        </ComboboxPopover>
       </Combobox>
     </div>
   );


### PR DESCRIPTION
The existing `openOnFocus` example mounts/unmounts the popover based on the results array state, which returns null if the input term is an empty string. This is confusing in the context of the `openOnFocus` prop because the popover doesn't show on focus if the input is empty.

An alternative to using hardcoded example options would be to use a variant of `useCityMatch` that returns an array of e.g. the first 10 cities if the input term is an empty string.

#### Old Example
![combobox-open-on-focus](https://user-images.githubusercontent.com/3409645/103576858-07062600-4e91-11eb-9c9d-e5573a0f7cd7.gif)

#### New Example
![new-combobox-open-on-focus](https://user-images.githubusercontent.com/3409645/103577172-8a277c00-4e91-11eb-87ed-28efb5d18731.gif)

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other