### PR TITLE
[skip-nav] Fix skip-nav tests

### DIFF
--- a/packages/skip-nav/__tests__/skip-nav.test.tsx
+++ b/packages/skip-nav/__tests__/skip-nav.test.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import { render /* act, fireEvent */ } from "$test/utils";
+import { render, userEvent, act, fireEvent } from "$test/utils";
 import { axe } from "jest-axe";
 import { SkipNavLink, SkipNavContent } from "@reach/skip-nav";
 
@@ -11,23 +11,26 @@ describe("<SkipNavLink />", () => {
     });
   });
 
-  // TODO: Doesn't pass, not sure why
-  //   it("should focus the SkipNavContent on click", () => {
-  //     let { getByText } = render(<Layout />);
-  //     act(() => {
-  //       fireEvent.click(getByText("Skip Nav"));
-  //       fireEvent.keyDown(document, { key: "Tab" });
-  //       expect(getByText("Focus me")).toHaveFocus();
-  //     });
-  //   });
-  //   it("should work with a custom ID", () => {
-  //     let { getByText } = render(<Layout skipNavId="whatever" />);
-  //     act(() => {
-  //       fireEvent.click(getByText("Skip Nav"));
-  //       fireEvent.keyDown(document, { key: "Tab" });
-  //       expect(getByText("Focus me")).toHaveFocus();
-  //     });
-  //   });
+  it("should focus the SkipNavContent on click", () => {
+    let { getByText, getByTestId } = render(<Layout />);
+    const mainContent = getByTestId("main");
+    act(() => {
+      userEvent.tab();
+      fireEvent.click(getByText("Skip Nav"));
+      userEvent.tab({ focusTrap: mainContent });
+      expect(getByText("Focus me")).toHaveFocus();
+    });
+  });
+  it("should work with a custom ID", () => {
+    let { getByText, getByTestId } = render(<Layout skipNavId="whatever" />);
+    const mainContent = getByTestId("main");
+    act(() => {
+      userEvent.tab();
+      fireEvent.click(getByText("Skip Nav"));
+      userEvent.tab({ focusTrap: mainContent });
+      expect(getByText("Focus me")).toHaveFocus();
+    });
+  });
 });
 
 function Layout({ skipNavId }: { skipNavId?: string }) {


### PR DESCRIPTION
This PR updates the skip-nav tests to use [userEvent.tab](https://testing-library.com/docs/ecosystem-user-event/#tabshift-focustrap). This recreates the same behaviour that we see in the browser. 

---------

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [X] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [X] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
