### PR TITLE
[menu-button] Prevent extraneous updates when clicking outside closed menus

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -890,6 +890,10 @@ const MenuPopover = forwardRefWithAs<MenuPopoverProps, "div">(
     const ref = useForkedRef(popoverRef, forwardedRef);
 
     React.useEffect(() => {
+      if (!isExpanded) {
+        return;
+      }
+
       let ownerDocument = getOwnerDocument(popoverRef.current)!;
       function listener(event: MouseEvent | TouchEvent) {
         if (buttonClickedRef.current) {
@@ -908,7 +912,14 @@ const MenuPopover = forwardRefWithAs<MenuPopoverProps, "div">(
         ownerDocument.removeEventListener("mousedown", listener);
         // ownerDocument.removeEventListener("touchstart", listener);
       };
-    }, [buttonClickedRef, buttonRef, dispatch, menuRef, popoverRef]);
+    }, [
+      buttonClickedRef,
+      buttonRef,
+      dispatch,
+      menuRef,
+      popoverRef,
+      isExpanded,
+    ]);
 
     let commonProps = {
       ref,


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [x] Other -- Prevents re-renders

If creating a new package:

(snipped)

----

I'm using potentially hundreds of menus in my project, and I've noticed that whenever I click anywhere, a lot of React re-renders occurred. With a small number of menus this doesn't matter, though.

This happens because the useReducer callback always returns a fresh object, even if it's deep-equal to the previously returned one. I checked what was being done to prevent re-renders for this reason, and I found many conditionals that check for the current state, and don't call `dispatch` if the state is already correct. So I've done this as well to prevent `document.addEventListener('mousedown')`.

I've verified that this works using the react profiler:

In the "At the Corners" storybook story, run the profiler, click a blank spot, and stop the profiler. You can see multiple re-renders:

![image](https://user-images.githubusercontent.com/1611595/106919819-63fc3280-6702-11eb-9da8-4847cd88d733.png)

After my patch, performing the same action doesn't cause any re-renders.