### PR TITLE
Add optional node container target to Portal

### DIFF
--- a/packages/portal/src/index.tsx
+++ b/packages/portal/src/index.tsx
@@ -20,7 +20,11 @@ import { createPortal } from "react-dom";
  *
  * @see Docs https://reach.tech/portal#portal
  */
-const Portal: React.FC<PortalProps> = ({ children, type = "reach-portal" }) => {
+const Portal: React.FC<PortalProps> = ({
+  children,
+  type = "reach-portal",
+  nodeContainer,
+}) => {
   let mountNode = React.useRef<HTMLDivElement | null>(null);
   let portalNode = React.useRef<HTMLElement | null>(null);
   let forceUpdate = useForceUpdate();
@@ -32,11 +36,12 @@ const Portal: React.FC<PortalProps> = ({ children, type = "reach-portal" }) => {
     // In that case, it's important to append to the correct document element.
     const ownerDocument = mountNode.current!.ownerDocument;
     portalNode.current = ownerDocument?.createElement(type)!;
-    ownerDocument!.body.appendChild(portalNode.current);
+    const container = nodeContainer || portalNode.current!.ownerDocument.body;
+    container.appendChild(portalNode.current);
     forceUpdate();
     return () => {
-      if (portalNode.current && portalNode.current.ownerDocument) {
-        portalNode.current.ownerDocument.body.removeChild(portalNode.current);
+      if (portalNode.current && container) {
+        container.removeChild(portalNode.current);
       }
     };
   }, [type, forceUpdate]);
@@ -64,6 +69,12 @@ type PortalProps = {
    * @see Docs https://reach.tech/portal#portal-type
    */
   type?: string;
+  /**
+   * Target DOM element to render the portal.
+   *
+   * @see Docs https://reach.tech/portal#portal-nodeContainer
+   */
+  nodeContainer?: HTMLElement;
 };
 
 if (__DEV__) {

--- a/packages/portal/src/index.tsx
+++ b/packages/portal/src/index.tsx
@@ -23,7 +23,7 @@ import { createPortal } from "react-dom";
 const Portal: React.FC<PortalProps> = ({
   children,
   type = "reach-portal",
-  nodeContainer,
+  container,
 }) => {
   let mountNode = React.useRef<HTMLDivElement | null>(null);
   let portalNode = React.useRef<HTMLElement | null>(null);
@@ -36,12 +36,12 @@ const Portal: React.FC<PortalProps> = ({
     // In that case, it's important to append to the correct document element.
     const ownerDocument = mountNode.current!.ownerDocument;
     portalNode.current = ownerDocument?.createElement(type)!;
-    const container = nodeContainer || portalNode.current!.ownerDocument.body;
-    container.appendChild(portalNode.current);
+    const body = container || ownerDocument.body;
+    body.appendChild(portalNode.current);
     forceUpdate();
     return () => {
-      if (portalNode.current && container) {
-        container.removeChild(portalNode.current);
+      if (portalNode.current && body) {
+        body.removeChild(portalNode.current);
       }
     };
   }, [type, forceUpdate]);
@@ -70,11 +70,11 @@ type PortalProps = {
    */
   type?: string;
   /**
-   * Target DOM element to render the portal.
+   * Target DOM node to render the portal.
    *
-   * @see Docs https://reach.tech/portal#portal-nodeContainer
+   * @see Docs https://reach.tech/portal#portal-container
    */
-  nodeContainer?: HTMLElement;
+  container?: Node;
 };
 
 if (__DEV__) {

--- a/packages/portal/src/index.tsx
+++ b/packages/portal/src/index.tsx
@@ -23,7 +23,7 @@ import { createPortal } from "react-dom";
 const Portal: React.FC<PortalProps> = ({
   children,
   type = "reach-portal",
-  container,
+  containerRef,
 }) => {
   let mountNode = React.useRef<HTMLDivElement | null>(null);
   let portalNode = React.useRef<HTMLElement | null>(null);
@@ -36,7 +36,7 @@ const Portal: React.FC<PortalProps> = ({
     // In that case, it's important to append to the correct document element.
     const ownerDocument = mountNode.current!.ownerDocument;
     portalNode.current = ownerDocument?.createElement(type)!;
-    const body = container || ownerDocument.body;
+    const body = containerRef?.current || ownerDocument.body;
     body.appendChild(portalNode.current);
     forceUpdate();
     return () => {
@@ -70,11 +70,11 @@ type PortalProps = {
    */
   type?: string;
   /**
-   * Target DOM node to render the portal.
+   * Optional container ref to render the portal in.
    *
-   * @see Docs https://reach.tech/portal#portal-container
+   * @see Docs https://reach.tech/portal#portal-containerRef
    */
-  container?: Node;
+  containerRef?: React.RefObject<any>;
 };
 
 if (__DEV__) {

--- a/website/src/pages/portal.mdx
+++ b/website/src/pages/portal.mdx
@@ -62,9 +62,10 @@ Renders content inside of a portal at the end of the DOM tree.
 
 #### Portal Props
 
-| Prop                    | Type | Required |
-| ----------------------- | ---- | -------- |
-| [`children`](#children) | node | true     |
+| Prop                    | Type   | Required |
+| ----------------------- | ------ | -------- |
+| [`children`](#children) | node   | true     |
+| [`type`](#type)         | string | false    |
 
 ##### Portal children
 

--- a/website/src/pages/portal.mdx
+++ b/website/src/pages/portal.mdx
@@ -62,11 +62,11 @@ Renders content inside of a portal at the end of the DOM tree.
 
 #### Portal Props
 
-| Prop                              | Type        | Required |
-| --------------------------------- | ----------- | -------- |
-| [`children`](#children)           | node        | true     |
-| [`type`](#type)                   | string      | false    |
-| [`nodeContainer`](#nodeContainer) | HTMLElement | false    |
+| Prop                      | Type   | Required |
+| ------------------------- | ------ | -------- |
+| [`children`](#children)   | node   | true     |
+| [`type`](#type)           | string | false    |
+| [`container`](#container) | Node   | false    |
 
 ##### Portal children
 
@@ -86,8 +86,8 @@ _Type_: `string` default: `reach-portal`
 
 The DOM element type to render.
 
-##### Portal nodeContainer
+##### Portal container
 
-_nodeContainer_: `HTMLElement` default: `document.body`
+_container_: `Node` default: `document.body`
 
-The DOM element container of the portal. If not set the portal will be appended to the body of the document.
+The DOM node container of the portal. If not set the portal will be appended to the body of the document.

--- a/website/src/pages/portal.mdx
+++ b/website/src/pages/portal.mdx
@@ -62,10 +62,11 @@ Renders content inside of a portal at the end of the DOM tree.
 
 #### Portal Props
 
-| Prop                    | Type   | Required |
-| ----------------------- | ------ | -------- |
-| [`children`](#children) | node   | true     |
-| [`type`](#type)         | string | false    |
+| Prop                              | Type        | Required |
+| --------------------------------- | ----------- | -------- |
+| [`children`](#children)           | node        | true     |
+| [`type`](#type)                   | string      | false    |
+| [`nodeContainer`](#nodeContainer) | HTMLElement | false    |
 
 ##### Portal children
 
@@ -84,3 +85,9 @@ Any content you want to render inside of the portal.
 _Type_: `string` default: `reach-portal`
 
 The DOM element type to render.
+
+##### Portal nodeContainer
+
+_nodeContainer_: `HTMLElement` default: `document.body`
+
+The DOM element container of the portal. If not set the portal will be appended to the body of the document.

--- a/website/src/pages/portal.mdx
+++ b/website/src/pages/portal.mdx
@@ -62,11 +62,11 @@ Renders content inside of a portal at the end of the DOM tree.
 
 #### Portal Props
 
-| Prop                      | Type   | Required |
-| ------------------------- | ------ | -------- |
-| [`children`](#children)   | node   | true     |
-| [`type`](#type)           | string | false    |
-| [`container`](#container) | Node   | false    |
+| Prop                            | Type   | Required |
+| ------------------------------- | ------ | -------- |
+| [`children`](#children)         | node   | true     |
+| [`type`](#type)                 | string | false    |
+| [`containerRef`](#containerRef) | ref    | false    |
 
 ##### Portal children
 
@@ -86,8 +86,8 @@ _Type_: `string` default: `reach-portal`
 
 The DOM element type to render.
 
-##### Portal container
+##### Portal containerRef
 
-_container_: `Node` default: `document.body`
+_containerRef_: `ref` default: `document.body`
 
-The DOM node container of the portal. If not set the portal will be appended to the body of the document.
+Ref to the container in where to render the portal. If not set the portal will be appended to the body of the document.


### PR DESCRIPTION
This PR aims to solve the issue #666.

It introduces a new optional prop for Portal: `nodeContainer` that allows the user to specify the containing node to render the Portal in.

If this PR is approved, then we can create a follow up PR to pass this prop to other relevant packages.

---

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [x] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [x] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

