### PR TITLE
[combobox] Fix binding value undesirely expands combobox

### DIFF
--- a/packages/combobox/examples/simulated-change.example.js
+++ b/packages/combobox/examples/simulated-change.example.js
@@ -1,0 +1,91 @@
+import * as React from "react";
+import {
+  Combobox,
+  ComboboxInput,
+  ComboboxList,
+  ComboboxOption,
+  ComboboxPopover,
+} from "@reach/combobox";
+import { useCityMatch } from "./utils";
+import "@reach/combobox/styles.css";
+
+let name = "Controlled";
+
+function Example() {
+  let [term, setTerm] = React.useState("Detroit");
+  let [selection, setSelection] = React.useState("");
+  let results = useCityMatch(term);
+  let ref = React.useRef();
+
+  const handleChange = (event) => {
+    setTerm(event.target.value);
+  };
+
+  const handleSelect = (value) => {
+    setSelection(value);
+    setTerm("");
+  };
+
+  const handleSimulateChange = () => {
+    setTerm("New York");
+  };
+
+  return (
+    <div>
+      <h2>Clientside Search</h2>
+      <p>
+        This example tests that changes to the controlled value of Combobox
+        don't trigger it to open unless we are actually typing. The initial
+        value and programmatically set value here shouldn't open the Popover.
+      </p>
+      <p>Selection: {selection}</p>
+      <p>Term: {term}</p>
+      <p>
+        <button onClick={handleSimulateChange}>
+          Set value programmatically
+        </button>
+      </p>
+      <Combobox onSelect={handleSelect} aria-label="choose a city">
+        <ComboboxInput
+          ref={ref}
+          value={term}
+          onChange={handleChange}
+          autocomplete={false}
+          style={{ width: 400 }}
+        />
+        {results && (
+          <ComboboxPopover>
+            {results.length === 0 && (
+              <p>
+                No Results{" "}
+                <button
+                  onClick={() => {
+                    setTerm("");
+                    ref.current.focus();
+                  }}
+                >
+                  clear
+                </button>
+              </p>
+            )}
+            <ComboboxList>
+              {results.slice(0, 10).map((result, index) => (
+                <ComboboxOption
+                  key={index}
+                  value={`${result.city}, ${result.state}`}
+                />
+              ))}
+            </ComboboxList>
+            <p>
+              <a href="/new">Add a record</a>
+            </p>
+          </ComboboxPopover>
+        )}
+      </Combobox>
+    </div>
+  );
+}
+
+Example.story = { name };
+export const Comp = Example;
+export default { title: "Combobox" };

--- a/packages/combobox/examples/simulated-change.example.js
+++ b/packages/combobox/examples/simulated-change.example.js
@@ -9,7 +9,7 @@ import {
 import { useCityMatch } from "./utils";
 import "@reach/combobox/styles.css";
 
-let name = "Controlled";
+let name = "Simulated Change";
 
 function Example() {
   let [term, setTerm] = React.useState("Detroit");
@@ -35,8 +35,8 @@ function Example() {
       <h2>Clientside Search</h2>
       <p>
         This example tests that changes to the controlled value of Combobox
-        don't trigger it to open unless we are actually typing. The initial
-        value and programmatically set value here shouldn't open the Popover.
+        don't expand it unless we are actually typing. The initial value and
+        programmatically set value here shouldn't open the Popover.
       </p>
       <p>Selection: {selection}</p>
       <p>Term: {term}</p>

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -486,10 +486,10 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
       (controlledValue!.trim() === "" ? (value || "").trim() !== "" : true)
     ) {
       handleValueChange(controlledValue!);
-      // After we handled the changed value, we need to make sure the next
-      // controlled change won't trigger a CHANGE event. (instead of a SIMULATED_CHANGE)
-      inputValueChangedRef.current = false;
     }
+    // After we handled the changed value, we need to make sure the next
+    // controlled change won't trigger a CHANGE event. (instead of a SIMULATED_CHANGE)
+    inputValueChangedRef.current = false;
   }, [controlledValue, handleValueChange, isControlled, value]);
 
   // [*]... and when controlled, we don't trigger handleValueChange as the


### PR DESCRIPTION
Closes https://github.com/reach/reach-ui/issues/755

This pull request fixes an issue where binding a controlled value undesirely expands combobox.

The change adds`inputValueChangedRef` to ComboboxInput and a new event type `SIMULATED_CHANGE`.

When the input triggers onChange, we set `inputValueChangedRef` to `true` and reset it to `false` after we detect a controlled value change. We then make call `CHANGE` only if this value is `true` when a change is detected, otherwise we call `SIMULATED_CHANGE`. This deprecates the `INITIAL_CHANGE` event type as it becomes a `SIMULATED_CHANGE`.

---

Thank you for contributing to Reach UI! Please 
fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
