### PR TITLE
menu-button(fix): fix selection when assistive tech on

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -337,6 +337,7 @@ const MenuItemImpl = React.forwardRef(function MenuItemImpl(
     onMouseUp,
     onSelect,
     disabled,
+    onFocus,
     valueText: valueTextProp,
     ...props
   },
@@ -433,7 +434,7 @@ const MenuItemImpl = React.forwardRef(function MenuItemImpl(
     dispatch({ type: CLEAR_SELECTION_INDEX });
   }
 
-  function handleMouseMove() {
+  function handleMouseMoveOrFocus() {
     readyToSelect.current = true;
     if (!isSelected && index != null && !disabled) {
       dispatch({ type: SELECT_ITEM_AT_INDEX, payload: { index } });
@@ -500,7 +501,8 @@ const MenuItemImpl = React.forwardRef(function MenuItemImpl(
       onMouseDown={composeEventHandlers(onMouseDown, handleMouseDown)}
       onMouseEnter={composeEventHandlers(onMouseEnter, handleMouseEnter)}
       onMouseLeave={composeEventHandlers(onMouseLeave, handleMouseLeave)}
-      onMouseMove={composeEventHandlers(onMouseMove, handleMouseMove)}
+      onMouseMove={composeEventHandlers(onMouseMove, handleMouseMoveOrFocus)}
+      onFocus={composeEventHandlers(onFocus, handleMouseMoveOrFocus)}
       onMouseUp={composeEventHandlers(onMouseUp, handleMouseUp)}
     />
   );


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

Issue:
Info about the problem here: https://github.com/reach/reach-ui/issues/805

Solution:
`mousemove` event is not being called because of the assistive technology, my suggestion is to use `onfocus` for these cases.


