### PR TITLE
[menu-button] Prevent default for links to avoid double click events

### DIFF
--- a/packages/menu-button/src/index.tsx
+++ b/packages/menu-button/src/index.tsx
@@ -662,10 +662,10 @@ const MenuItems = React.forwardRef(function MenuItems(
           // consistent behavior across menu items we'll trigger a click when
           // the spacebar is pressed.
           if (selected) {
+            event.preventDefault();
             if (selected.isLink && selected.element) {
               selected.element.click();
             } else {
-              event.preventDefault();
               // Focus the button first by default when an item is selected.
               // We fire the onSelect callback next so the app can manage
               // focus if needed.


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [X] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

Fixes #811.  

I found that without preventing the original event's default, I was getting two click events, and one would fire inside a Dialog that I was opening, immediately closing it.  This ensures the original event is prevented when creating a new .click() on a link.
