### PR TITLE
Descendants: Fix a bug where new items get wrong index

### DIFF
--- a/packages/descendants/src/index.tsx
+++ b/packages/descendants/src/index.tsx
@@ -64,7 +64,7 @@ function useDescendant<DescendantType extends Descendant>(
 
     registerDescendant({
       ...descendant,
-      index,
+      index: index === -1 ? null : index,
     } as DescendantType);
     return () => {
       unregisterDescendant(descendant.element);


### PR DESCRIPTION
Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [X] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

---

I noticed when using the descendants package that `registerDescendant` is always getting called with a set index, never null. It looks to me as if the `set` method inside `registerDescendant` is meant to get `index === null` when a new element has been added and needs to be compared to its siblings in the DOM via `compareDocumentPosition`. Instead, the newest items all come in with `index: -1`, then get sorted to the front of the items array and treated as if they're the first descendants, even when they're not.

I admit that I wasn't able to properly build a test for this fix because I couldn't figure out how to set up the repo on my own machine. Fortunately, I was able to copy/paste the entire descendants file into my project and verify that the fix is working. Perhaps @chaance can help create a better test?