### PR TITLE
Combobox: Respect targetRef at ComboboxPopover component

### DIFF
--- a/packages/combobox/examples/token-input.example.js
+++ b/packages/combobox/examples/token-input.example.js
@@ -18,6 +18,8 @@ function Example() {
   let [term, setTerm] = React.useState("");
   let [selections, setSelections] = React.useState([]);
   let results = useCityMatch(term);
+  let containerRef = React.useRef();
+  let [customTargetMode, setCustomTargetMode] = React.useState(false);
 
   const handleChange = (event) => {
     setTerm(event.target.value);
@@ -28,61 +30,77 @@ function Example() {
     setTerm("");
   };
 
+  const comboboxPopoverTargetRef = customTargetMode ? containerRef : undefined;
+
   return (
     <div>
       <h2>Tokenbox</h2>
-      <ExampleTokenbox onSelect={handleSelect}>
-        <ExampleTokenLabel
-          onRemove={(item) => {
-            setSelections(selections.filter((s) => s !== item));
-          }}
-          style={{
-            border: "1px solid #888",
-            display: "flex",
-            flexWrap: "wrap",
-          }}
-        >
-          {selections.map((selection) => (
-            <ExampleToken value={selection} />
-          ))}
-          <ExampleTokenInput
-            value={term}
-            onChange={handleChange}
-            autocomplete={false}
-            style={{
-              outline: "none",
-              border: "none",
-              flexGrow: 1,
-              margin: "0.25rem",
-              font: "inherit",
+
+      <label style={{ display: "block", marginBottom: "24px" }}>
+        <input
+          type="checkbox"
+          name="customTargetMode"
+          checked={customTargetMode}
+          onChange={(event) => setCustomTargetMode(event.target.checked)}
+        />
+        Set combobox container element as <code>targetRef</code> for suggestions
+        popover element
+      </label>
+
+      <div ref={containerRef}>
+        <ExampleTokenbox onSelect={handleSelect}>
+          <ExampleTokenLabel
+            onRemove={(item) => {
+              setSelections(selections.filter((s) => s !== item));
             }}
-          />
-        </ExampleTokenLabel>
-        {results && (
-          <ComboboxPopover>
-            {results.length === 0 && (
-              <p>
-                No Results{" "}
-                <button
-                  onClick={() => {
-                    setTerm("");
-                  }}
-                >
-                  clear
-                </button>
-              </p>
-            )}
-            <ComboboxList>
-              {results.slice(0, 10).map((result, index) => (
-                <ComboboxOption
-                  key={index}
-                  value={`${result.city}, ${result.state}`}
-                />
-              ))}
-            </ComboboxList>
-          </ComboboxPopover>
-        )}
-      </ExampleTokenbox>
+            style={{
+              border: "1px solid #888",
+              display: "flex",
+              flexWrap: "wrap",
+            }}
+          >
+            {selections.map((selection) => (
+              <ExampleToken value={selection} />
+            ))}
+            <ExampleTokenInput
+              value={term}
+              onChange={handleChange}
+              autocomplete={false}
+              style={{
+                outline: "none",
+                border: "none",
+                flexGrow: 1,
+                margin: "0.25rem",
+                font: "inherit",
+              }}
+            />
+          </ExampleTokenLabel>
+          {results && (
+            <ComboboxPopover portal={true} targetRef={comboboxPopoverTargetRef}>
+              {results.length === 0 && (
+                <p>
+                  No Results{" "}
+                  <button
+                    onClick={() => {
+                      setTerm("");
+                    }}
+                  >
+                    clear
+                  </button>
+                </p>
+              )}
+              <ComboboxList>
+                {results.slice(0, 10).map((result, index) => (
+                  <ComboboxOption
+                    key={index}
+                    value={`${result.city}, ${result.state}`}
+                  />
+                ))}
+              </ComboboxList>
+            </ComboboxPopover>
+          )}
+        </ExampleTokenbox>
+      </div>
     </div>
   );
 }

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -623,6 +623,7 @@ export const ComboboxPopover = React.forwardRef(function ComboboxPopover(
     onKeyDown,
     onBlur,
     position = positionMatchWidth,
+    targetRef,
     ...props
   },
   forwardedRef
@@ -654,7 +655,7 @@ export const ComboboxPopover = React.forwardRef(function ComboboxPopover(
       {...props}
       ref={ref}
       position={position}
-      targetRef={inputRef}
+      targetRef={targetRef ?? inputRef}
       {...sharedProps}
     />
   ) : (


### PR DESCRIPTION
## Context 

Sometimes (pretty often) we have to change the target ref of the Combobox Popover element in case if we want to build something new with `@reach/combobox`. A good example of that can be a multi-Combobox with pills. I think this problem has been described already in this issue https://github.com/reach/reach-ui/issues/543. 

This PR fixes the problem when you can't pass a custom target ref to the `<ComboboxPopover />` explicitly.

<table>
 <tr>
   <th>With input as a ref</th>
   <th>With combobox wrap as a ref</th>
 </tr>
 
 <tr>
   <td>
   
   
<img width="508" alt="Screenshot 2021-10-08 at 00 03 27" src="https://user-images.githubusercontent.com/18492575/136461977-c0584cd1-448f-4549-bd5c-904e15f949fc.png">

   </td>
   
   <td>
      
      
<img width="519" alt="image" src="https://user-images.githubusercontent.com/18492575/136461962-eaeef66c-3f77-4868-95cb-a90f4538d5fc.png">

   </td>
 </tr>
</table>

This PR also updates tokens Combobox a little bit and shows new case usage with `targetRef` at `<ComboboxPopover />`
