### PR TITLE
docs: Adds `contentId` to SkipNavLink docs

### DIFF
--- a/website/src/pages/skip-nav.mdx
+++ b/website/src/pages/skip-nav.mdx
@@ -64,14 +64,29 @@ Renders a link that remains hidden until focused to skip to the main content.
 
 #### SkipNavLink Props
 
-| Prop                                   | Type   | Required |
-| -------------------------------------- | ------ | -------- |
-| [`a` props](#skipnavlink-anchor-props) | Cool   |          |
-| [`children`](#skipnavlink-children)    | `node` | false    |
+| Prop                                   | Type    | Required |
+| -------------------------------------- | ------- | -------- |
+| [`a` props](#skipnavlink-anchor-props) | Cool    |          |
+| [`contentId`](#skipnavlink-contentid)  | `string`| false    |
+| [`children`](#skipnavlink-children)    | `node`  | false    |
 
 ##### SkipNavLink anchor props
 
 Element props are spread to the underlying link.
+
+#### SkipNavLink `contentId`
+
+You can pass an id that connects the skip link to the element where it should link to. You can use this instead of using `SkipNavContent`. For example: 
+
+```jsx
+<SkipNavLink contentId="main" />
+<div>
+  <YourNav />
+  <main id="main">
+    //...
+  </main>
+</div>
+```
 
 ##### SkipNavLink `children`
 

--- a/website/src/pages/skip-nav.mdx
+++ b/website/src/pages/skip-nav.mdx
@@ -64,11 +64,11 @@ Renders a link that remains hidden until focused to skip to the main content.
 
 #### SkipNavLink Props
 
-| Prop                                   | Type    | Required |
-| -------------------------------------- | ------- | -------- |
-| [`a` props](#skipnavlink-anchor-props) | Cool    |          |
-| [`contentId`](#skipnavlink-contentid)  | `string`| false    |
-| [`children`](#skipnavlink-children)    | `node`  | false    |
+| Prop                                   | Type    | Required | Default          |
+| -------------------------------------- | ------- | -------- | ---------------- |
+| [`a` props](#skipnavlink-anchor-props) | Cool    |          | n/a              |
+| [`contentId`](#skipnavlink-contentid)  | `string`| false    | 'reach-skip-nav' |
+| [`children`](#skipnavlink-children)    | `node`  | false    | n/a              |
 
 ##### SkipNavLink anchor props
 


### PR DESCRIPTION
This PR updates the `SkipNavLink` docs to include the `contentId` prop! It's a super helpful prop and I wanted to make sure folks knew about it. 

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- n/a Test the change in your own code (Compile and run).
- n/a Add or edit tests to reflect the change (Run with `yarn test`).
- n/a  Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- n/a Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [X] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
