### PR TITLE
Combobox: Up arrow in IDLE state now passes persistSelection to navigate, the same that down arrow does

### DIFF
--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -1079,7 +1079,10 @@ function useKeyDown() {
         }
 
         if (state === IDLE) {
-          transition(NAVIGATE);
+          // Opening a closed list
+          transition(NAVIGATE, {
+            persistSelection: persistSelectionRef.current,
+          });
         } else {
           let prev = getPreviousOption();
           transition(NAVIGATE, { value: prev ? prev.value : null });


### PR DESCRIPTION
Tiny fix to make the up arrow key behave the same that the down arrow key does when in IDLE state.

- [YES ] Use a meaningful title for the pull request. Include the name of the package modified.
- [YES] Test the change in your own code (Compile and run).
- [NA] Add or edit tests to reflect the change (Run with `yarn test`).
- [NA] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [YES] Ensure formatting is consistent with the project's Prettier configuration.
- [NA] Add documentation to support any new features.

This pull request: **Fixes a bug in an existing package**

**Not a new package.**
