### PR TITLE
Fix selection for controlled combobox

### DIFF
--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -313,7 +313,6 @@ export const Combobox = React.forwardRef(function Combobox(
   let listboxId = id ? makeId("listbox", id) : "listbox";
 
   let isControlledRef = React.useRef<boolean>(false);
-  let setIsControlled = (val: boolean) => (isControlledRef.current = val);
 
   let context: InternalComboboxContextValue = {
     ariaLabel,
@@ -331,8 +330,7 @@ export const Combobox = React.forwardRef(function Combobox(
     popoverRef,
     state,
     transition,
-    isControlled: isControlledRef.current,
-    setIsControlled,
+    isControlledRef,
   };
 
   useCheckStyles("combobox");
@@ -451,7 +449,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
     ariaLabel,
     ariaLabelledby,
     persistSelectionRef,
-    setIsControlled,
+    isControlledRef,
   } = React.useContext(ComboboxContext);
 
   let ref = useComposedRefs(inputRef, forwardedRef);
@@ -467,7 +465,7 @@ export const ComboboxInput = React.forwardRef(function ComboboxInput(
   let isControlled = controlledValue != null;
 
   React.useEffect(() => {
-    setIsControlled(isControlled);
+    isControlledRef.current = isControlled;
   }, [isControlled]);
 
   // Layout effect should be SSR-safe here because we don't actually do
@@ -772,7 +770,7 @@ export const ComboboxOption = React.forwardRef(function ComboboxOption(
     onSelect,
     data: { navigationValue },
     transition,
-    isControlled,
+    isControlledRef,
   } = React.useContext(ComboboxContext);
 
   let ownRef = React.useRef<HTMLElement | null>(null);
@@ -795,7 +793,10 @@ export const ComboboxOption = React.forwardRef(function ComboboxOption(
 
   let handleClick = () => {
     onSelect && onSelect(value);
-    transition(SELECT_WITH_CLICK, { value, isControlled });
+    transition(SELECT_WITH_CLICK, {
+      value,
+      isControlled: isControlledRef.current,
+    });
   };
 
   return (
@@ -1331,8 +1332,7 @@ interface InternalComboboxContextValue {
   popoverRef: React.MutableRefObject<HTMLElement | undefined>;
   state: State;
   transition: Transition;
-  isControlled: boolean;
-  setIsControlled: (val: boolean) => void;
+  isControlledRef: React.MutableRefObject<boolean>;
 }
 
 type Transition = (event: MachineEventType, payload?: any) => any;

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -195,7 +195,8 @@ const reducer: Reducer = (data: StateData, event: MachineEvent) => {
     case SELECT_WITH_KEYBOARD:
       return {
         ...nextState,
-        value: data.navigationValue,
+        // if controlled, "set" the input to what it already has, and let the user do whatever they want
+        value: event.isControlled ? data.value : data.navigationValue,
         navigationValue: null,
       };
     case CLOSE_WITH_BUTTON:
@@ -1010,6 +1011,7 @@ function useKeyDown() {
     transition,
     autocompletePropRef,
     persistSelectionRef,
+    isControlledRef,
   } = React.useContext(ComboboxContext);
 
   let options = useDescendants(ComboboxDescendantContext);
@@ -1139,7 +1141,9 @@ function useKeyDown() {
           // don't want to submit forms
           event.preventDefault();
           onSelect && onSelect(navigationValue);
-          transition(SELECT_WITH_KEYBOARD);
+          transition(SELECT_WITH_KEYBOARD, {
+            isControlled: isControlledRef.current,
+          });
         }
         break;
     }
@@ -1397,6 +1401,7 @@ type MachineEvent =
     }
   | {
       type: "SELECT_WITH_KEYBOARD";
+      isControlled: boolean;
     };
 
 type Reducer = (data: StateData, event: MachineEvent) => StateData;

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -312,8 +312,7 @@ export const Combobox = React.forwardRef(function Combobox(
   let id = useId(props.id);
   let listboxId = id ? makeId("listbox", id) : "listbox";
 
-  let isControlledRef = React.useRef<boolean>(false);
-  let setIsControlled = (val: boolean) => (isControlledRef.current = val);
+  let [isControlled, setIsControlled] = React.useState(false);
 
   let context: InternalComboboxContextValue = {
     ariaLabel,
@@ -331,7 +330,7 @@ export const Combobox = React.forwardRef(function Combobox(
     popoverRef,
     state,
     transition,
-    isControlled: isControlledRef.current,
+    isControlled,
     setIsControlled,
   };
 

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -188,7 +188,8 @@ const reducer: Reducer = (data: StateData, event: MachineEvent) => {
     case SELECT_WITH_CLICK:
       return {
         ...nextState,
-        value: event.isControlled ? null : event.value,
+        // if controlled, "set" the input to what it already has, and let the user do whatever they want
+        value: event.isControlled ? data.value : event.value,
         navigationValue: null,
       };
     case SELECT_WITH_KEYBOARD:

--- a/packages/combobox/src/index.tsx
+++ b/packages/combobox/src/index.tsx
@@ -312,7 +312,8 @@ export const Combobox = React.forwardRef(function Combobox(
   let id = useId(props.id);
   let listboxId = id ? makeId("listbox", id) : "listbox";
 
-  let [isControlled, setIsControlled] = React.useState(false);
+  let isControlledRef = React.useRef<boolean>(false);
+  let setIsControlled = (val: boolean) => (isControlledRef.current = val);
 
   let context: InternalComboboxContextValue = {
     ariaLabel,
@@ -330,7 +331,7 @@ export const Combobox = React.forwardRef(function Combobox(
     popoverRef,
     state,
     transition,
-    isControlled,
+    isControlled: isControlledRef.current,
     setIsControlled,
   };
 


### PR DESCRIPTION
Here's the context. In the existing Storybook, go to combobox controlled (third one). Then repeatedly type in the box, and select something. Occasionally (roughly 1 in 5 times) you'll see the text of the thing you select flash in the input, before being cleared. To make this more pronounced, and easier to see, edit this code:

```js
    case SELECT_WITH_CLICK:
      return {
        ...nextState,
        value: event.value,
        navigationValue: null,
      };
```

to this

```js
    case SELECT_WITH_CLICK:
      return {
        ...nextState,
        value: "XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX",
        navigationValue: null,
      };
```

This PR fixes that, by changing the value to null when the combobox is used in controlled mode. 

--- 

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [x] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
