### PR TITLE
Docs: escape vertical bar in CustomCheckbox Props table

### DIFF
--- a/website/src/pages/checkbox.mdx
+++ b/website/src/pages/checkbox.mdx
@@ -431,7 +431,7 @@ Please see the [styling guide](/styling).
 | [`disabled`](#customcheckbox-disabled)             | `boolean`                    | false    |
 | [`name`](#customcheckbox-name)                     | `string`                     | false    |
 | [`onChange`](#customcheckbox-onchange)             | `func`                       | false    |
-| [`value`](#customcheckbox-value)                   | `string | number`            | false    |
+| [`value`](#customcheckbox-value)                   | `string \| number`           | false    |
 
 ##### CustomCheckbox `span` props
 


### PR DESCRIPTION
Hi I saw this little documentation bug when I was looking at the site and thought I'd fix it if it were on github. And here it is! 🎉

Sorry most of the template items I left unchecked, as they are not applicable.

---------

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
