### PR TITLE
[listbox] add dynamic content example to reproduce bug with keyboard selection order.

### DIFF
--- a/playground/stories/listbox.story.ts
+++ b/playground/stories/listbox.story.ts
@@ -1,6 +1,7 @@
 export { Example as Basic } from "./listbox/basic.example";
 export { Example as Composed } from "./listbox/composed.example";
 export { Example as Controlled } from "./listbox/controlled.example";
+export { Example as Dynamic } from "./listbox/dynamic-content.example";
 export { Example as FocusOnSelect } from "./listbox/focus-on-select.example";
 export { Example as GroupedComposedLabel } from "./listbox/grouped-composed-label.example";
 export { Example as GroupedTS } from "./listbox/grouped.example";

--- a/playground/stories/listbox/dynamic-content.example.tsx
+++ b/playground/stories/listbox/dynamic-content.example.tsx
@@ -1,0 +1,45 @@
+import * as React from "react";
+import VisuallyHidden from "@reach/visually-hidden";
+import { Listbox, ListboxOption } from "@reach/listbox";
+import "@reach/listbox/styles.css";
+
+let name = "Dynamic content";
+
+function Example() {
+  let [guestCount, setGuestCount] = React.useState(1);
+
+  const options = Array.from({ length: guestCount }).map((_, i) => {
+    const roomCount = i + 1;
+    return {
+      value: roomCount.toString(),
+      label: `${roomCount} ${roomCount > 1 ? "rooms" : "room"}`,
+    };
+  });
+
+  return (
+    <div>
+      <span>
+        {guestCount} {guestCount > 1 ? "guests " : "guest "}
+      </span>
+      <button type="button" onClick={() => setGuestCount(guestCount + 1)}>
+        Add one more guest
+      </button>
+      <hr />
+      <VisuallyHidden id="room-label">Select rooms</VisuallyHidden>
+      <Listbox aria-labelledby="room-label" defaultValue="1">
+        {options.map((option) => (
+          <ListboxOption
+            key={option.value}
+            value={option.value}
+            label={option.label}
+          >
+            {option.label}
+          </ListboxOption>
+        ))}
+      </Listbox>
+    </div>
+  );
+}
+
+Example.storyName = name;
+export { Example };


### PR DESCRIPTION
These changes add an example to reproduce a bug that is fixed by https://github.com/reach/reach-ui/pull/827

I noticed a bug in the Listbox component when adding ListboxOptions dynamically to it. The keyboard selection order is scrambled. Luckily, there's an open PR to fix the bug.

To reproduce:

1. Navigate to new example in Storybook http://localhost:9001/?path=/story/listbox--dynamic-content-ts
2. Click two times on the "Add one more guest" button. This adds two more options to the listbox.
3. Click the listbox open, the "1 room" options should be selected
4. Press the "down arrow" key, I expected "2 rooms" to be selected, but instead "3 rooms" is selected.

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [X] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [X] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [X] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
