### PR TITLE
[Dialog] Add Custom portal target prop to DialogOverlay

### DIFF
--- a/packages/dialog/examples/index.story.js
+++ b/packages/dialog/examples/index.story.js
@@ -13,6 +13,7 @@ export { Example as Dropdown } from "./dropdown.example.js";
 export { Example as LongContent } from "./long-content.example.js";
 export { Example as Nested } from "./nested.example.js";
 export { Example as NoTabbables } from "./no-tabbables.example.js";
+export { Example as WithCustomPortalTarget } from "./with-custom-portal-target.example.js";
 export { Example as WithDialogOverlay } from "./with-dialog-overlay.example.js";
 export { Example as WithTooltip } from "./with-tooltip.example.js";
 export { Example as WithWrappedComponents } from "./with-wrapped-components.example.js";

--- a/packages/dialog/examples/with-custom-portal-target.example.js
+++ b/packages/dialog/examples/with-custom-portal-target.example.js
@@ -1,0 +1,28 @@
+import * as React from "react";
+import { DialogOverlay, DialogContent } from "@reach/dialog";
+import "@reach/dialog/styles.css";
+
+let name = "With Custom Portal Target";
+
+function Example() {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const containerRef = React.useRef();
+  return (
+    <div ref={containerRef}>
+      <button onClick={() => setShowDialog(true)}>Show Dialog</button>
+      <DialogOverlay
+        aria-label="Announcement"
+        isOpen={showDialog}
+        onDismiss={() => setShowDialog(false)}
+        portalTargetRef={containerRef}
+      >
+        <DialogContent aria-labelledby="Announcement">
+          <p>This Dialog will be rendered within a custom DOM Node.</p>
+        </DialogContent>
+      </DialogOverlay>
+    </div>
+  );
+}
+
+Example.storyName = name;
+export { Example };

--- a/packages/dialog/examples/with-custom-portal-target.example.js
+++ b/packages/dialog/examples/with-custom-portal-target.example.js
@@ -14,7 +14,7 @@ function Example() {
         aria-label="Announcement"
         isOpen={showDialog}
         onDismiss={() => setShowDialog(false)}
-        portalTargetRef={containerRef}
+        containerRef={containerRef}
       >
         <DialogContent aria-labelledby="Announcement">
           <p>This Dialog will be rendered within a custom DOM Node.</p>

--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -46,7 +46,7 @@ const overlayPropTypes = {
  * @see Docs https://reach.tech/dialog#dialogoverlay
  */
 const DialogOverlay = React.forwardRef(function DialogOverlay(
-  { as: Comp = "div", portalTargetRef, isOpen = true, ...props },
+  { as: Comp = "div", containerRef, isOpen = true, ...props },
   forwardedRef
 ) {
   useCheckStyles("dialog");
@@ -68,7 +68,7 @@ const DialogOverlay = React.forwardRef(function DialogOverlay(
   }, [isOpen]);
 
   return isOpen ? (
-    <Portal data-reach-dialog-wrapper="" containerRef={portalTargetRef}>
+    <Portal data-reach-dialog-wrapper="" containerRef={containerRef}>
       <DialogInner ref={forwardedRef} as={Comp} {...props} />
     </Portal>
   ) : null;
@@ -91,7 +91,7 @@ interface DialogOverlayProps extends DialogProps {
    *
    * @see Docs https://reach.tech/dialog#dialogoverlay-portaltargetref
    */
-  portalTargetRef?: React.RefObject<Node>;
+  containerRef?: React.RefObject<Node>;
   /**
    * By default the dialog locks the focus inside it. Normally this is what you
    * want. This prop is provided so that this feature can be disabled. This,

--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -89,7 +89,7 @@ interface DialogOverlayProps extends DialogProps {
    * portal will be appended to the body of the component's owner document
    * (typically this is the `document.body`).
    *
-   * @see Docs https://reach.tech/dialog#dialog-portalTargetRef
+   * @see Docs https://reach.tech/dialog#dialogoverlay-portaltargetref
    */
   portalTargetRef?: React.RefObject<Node>;
   /**

--- a/packages/dialog/src/index.tsx
+++ b/packages/dialog/src/index.tsx
@@ -46,7 +46,7 @@ const overlayPropTypes = {
  * @see Docs https://reach.tech/dialog#dialogoverlay
  */
 const DialogOverlay = React.forwardRef(function DialogOverlay(
-  { as: Comp = "div", isOpen = true, ...props },
+  { as: Comp = "div", portalTargetRef, isOpen = true, ...props },
   forwardedRef
 ) {
   useCheckStyles("dialog");
@@ -68,7 +68,7 @@ const DialogOverlay = React.forwardRef(function DialogOverlay(
   }, [isOpen]);
 
   return isOpen ? (
-    <Portal data-reach-dialog-wrapper="">
+    <Portal data-reach-dialog-wrapper="" containerRef={portalTargetRef}>
       <DialogInner ref={forwardedRef} as={Comp} {...props} />
     </Portal>
   ) : null;
@@ -83,6 +83,15 @@ if (__DEV__) {
 }
 
 interface DialogOverlayProps extends DialogProps {
+  /**
+   * The DialogOverlay is always rendered in a portal.
+   * This props determined the container to which the portal will be appended. If not set the
+   * portal will be appended to the body of the component's owner document
+   * (typically this is the `document.body`).
+   *
+   * @see Docs https://reach.tech/dialog#dialog-portalTargetRef
+   */
+  portalTargetRef?: React.RefObject<Node>;
   /**
    * By default the dialog locks the focus inside it. Normally this is what you
    * want. This prop is provided so that this feature can be disabled. This,
@@ -332,7 +341,6 @@ interface DialogProps {
    * @see Docs https://reach.tech/dialog#dialog-children
    */
   children?: React.ReactNode;
-
   /**
    * By default the first focusable element will receive focus when the dialog
    * opens but you can provide a ref to focus instead.

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -327,7 +327,7 @@ Use the following CSS to target the overlay:
 | [`initialFocusRef`](#dialogoverlay-initialfocusref)                  | `ref`  | false    |
 | [`isOpen`](#dialogoverlay-isopen)                                    | `bool` | false    |
 | [`onDismiss`](#dialogoverlay-ondismiss)                              | `func` | false    |
-| [`portalTargetRef`](#dialogoverlay-portaltargetref)                  | `ref`  | false    |
+| [`containerRef`](#dialogoverlay-portaltargetref)                     | `ref`  | false    |
 
 ##### DialogOverlay `div` props
 
@@ -433,9 +433,9 @@ Same as [Dialog `isOpen`](#dialog-isopen).
 
 Same as [Dialog `onDismiss`](#dialog-ondismiss).
 
-##### DialogOverlay `portalTargetRef`
+##### DialogOverlay `containerRef`
 
-`portalTargetRef?: React.RefObject<Node>`
+`containerRef?: React.RefObject<Node>`
 
 By default the DialogOverlay will be rendered to the `body` element via a portal. This prop allows you to set a custom node as the portal
 target as an alternative to the `body`.
@@ -454,7 +454,7 @@ function Example(props) {
       <DialogOverlay
         isOpen={showDialog}
         onDismiss={close}
-        portalTargetRef={containerRef}
+        containerRef={containerRef}
       >
         <DialogContent aria-labelledby="Announcement">
           <p>This Dialog will be rendered within a custom DOM Node.</p>

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -327,7 +327,7 @@ Use the following CSS to target the overlay:
 | [`initialFocusRef`](#dialogoverlay-initialfocusref)                  | `ref`  | false    |
 | [`isOpen`](#dialogoverlay-isopen)                                    | `bool` | false    |
 | [`onDismiss`](#dialogoverlay-ondismiss)                              | `func` | false    |
-| [`containerRef`](#dialogoverlay-portaltargetref)                     | `ref`  | false    |
+| [`containerRef`](#dialogoverlay-containerref)                        | `ref`  | false    |
 
 ##### DialogOverlay `div` props
 

--- a/website/src/pages/dialog.mdx
+++ b/website/src/pages/dialog.mdx
@@ -327,6 +327,7 @@ Use the following CSS to target the overlay:
 | [`initialFocusRef`](#dialogoverlay-initialfocusref)                  | `ref`  | false    |
 | [`isOpen`](#dialogoverlay-isopen)                                    | `bool` | false    |
 | [`onDismiss`](#dialogoverlay-ondismiss)                              | `func` | false    |
+| [`portalTargetRef`](#dialogoverlay-portaltargetref)                  | `ref`  | false    |
 
 ##### DialogOverlay `div` props
 
@@ -431,6 +432,38 @@ Same as [Dialog `isOpen`](#dialog-isopen).
 ##### DialogOverlay `onDismiss`
 
 Same as [Dialog `onDismiss`](#dialog-ondismiss).
+
+##### DialogOverlay `portalTargetRef`
+
+`portalTargetRef?: React.RefObject<Node>`
+
+By default the DialogOverlay will be rendered to the `body` element via a portal. This prop allows you to set a custom node as the portal
+target as an alternative to the `body`.
+
+```jsx
+function Example(props) {
+  const [showDialog, setShowDialog] = React.useState(false);
+  const containerRef = React.useRef();
+  const open = () => setShowDialog(true);
+  const close = () => setShowDialog(false);
+
+  return (
+    <div ref={containerRef}>
+      <button onClick={open}>Open Dialog</button>
+
+      <DialogOverlay
+        isOpen={showDialog}
+        onDismiss={close}
+        portalTargetRef={containerRef}
+      >
+        <DialogContent aria-labelledby="Announcement">
+          <p>This Dialog will be rendered within a custom DOM Node.</p>
+        </DialogContent>
+      </DialogOverlay>
+    </div>
+  );
+}
+```
 
 ### DialogContent
 


### PR DESCRIPTION
Hi all, this PR adds the functionality requested in this issue: https://github.com/reach/reach-ui/issues/900

Basically it allows users of `DialogOverlay` to set a custom node for the portal target.

- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [X] Add or edit tests to reflect the change (Run with `yarn test`).
- [X] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [X] Ensure formatting is consistent with the project's Prettier configuration.
- [X] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [X] Adds additional features/functionality to an existing package
- [X] Updates documentation or example code
- [ ] Other
