### PR TITLE
[ListboxInput]: Update submit button querySelector specificity

### DIFF
--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,9 +228,7 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let submitButton = hiddenInput.form.querySelector(
-      "[type='submit'],form button"
-    );
+    let submitButton = hiddenInput.form.querySelector("[type='submit']");
     submitButton && (submitButton as any).click();
   }
 }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,9 +228,7 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let submitButton = hiddenInput.form.querySelector(
-      "[type='submit'], button"
-    );
+    let submitButton = hiddenInput.form.querySelector("[type='submit'],button");
     submitButton && (submitButton as any).click();
   }
 }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,7 +228,9 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let submitButton = hiddenInput.form.querySelector("[type='submit'],button");
+    let submitButton = hiddenInput.form.querySelector(
+      "[type='submit'],form button"
+    );
     submitButton && (submitButton as any).click();
   }
 }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -229,7 +229,7 @@ function submitForm(data: ListboxStateData, event: any) {
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
     let submitButton = hiddenInput.form.querySelector(
-      'button:not([type]),[type="submit"]'
+      "button:not([type]),[type='submit']"
     );
     submitButton && (submitButton as any).click();
   }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,8 +228,9 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let { form } = hiddenInput;
-    let submitButton = form.querySelector('button:not([type]),[type="submit"]');
+    let submitButton = hiddenInput.form.querySelector(
+      'button:not([type]),[type="submit"]'
+    );
     submitButton && (submitButton as any).click();
   }
 }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,7 +228,7 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let submitButton = hiddenInput.form.querySelector("button,[type='submit']");
+    let submitButton = hiddenInput.form.querySelector("button[type='submit']");
     submitButton && (submitButton as any).click();
   }
 }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,7 +228,9 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let submitButton = hiddenInput.form.querySelector("button[type='submit']");
+    let submitButton = hiddenInput.form.querySelector(
+      "[type='submit'], button"
+    );
     submitButton && (submitButton as any).click();
   }
 }

--- a/packages/listbox/src/machine.ts
+++ b/packages/listbox/src/machine.ts
@@ -228,7 +228,8 @@ function submitForm(data: ListboxStateData, event: any) {
   // sucker.
   let { hiddenInput } = event.refs;
   if (hiddenInput && hiddenInput.form) {
-    let submitButton = hiddenInput.form.querySelector("[type='submit']");
+    let { form } = hiddenInput;
+    let submitButton = form.querySelector('button:not([type]),[type="submit"]');
     submitButton && (submitButton as any).click();
   }
 }


### PR DESCRIPTION
Hello, our website has a Listbox within a form. When we press enter on the Listbox, it is currently clicking the first button that it finds on the page and not our submit button.  This PR updates the specificity of the selector to select the first button without a type or the first item with type=submit.

Thank you! 

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [x] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
https://github.com/reach/reach-ui/issues/904
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
