### PR TITLE
[Alert]: Make the Alert itself aria-live to dedupe screen reader announcement

### DIFF
--- a/packages/alert/src/index.tsx
+++ b/packages/alert/src/index.tsx
@@ -7,7 +7,7 @@
  * readers, and in some operating systems, they may trigger an alert sound.
  *
  * The approach here is to allow developers to render a visual <Alert> and then
- * we mirror that to a couple of aria-live regions behind the scenes. This way,
+ * we treat it as an aria-live region behind the scenes. This way,
  * most of the time, developers don't have to think about visual vs. aria
  * alerts.
  *
@@ -23,37 +23,10 @@
  * @see WAI-ARIA https://www.w3.org/TR/wai-aria-practices-1.2/#alert
  */
 import * as React from "react";
-import * as ReactDOM from "react-dom";
-import { VisuallyHidden } from "@reach/visually-hidden";
-import { usePrevious } from "@reach/utils/use-previous";
-import { getOwnerDocument } from "@reach/utils/owner-document";
 import { useComposedRefs } from "@reach/utils/compose-refs";
 import PropTypes from "prop-types";
 
 import type * as Polymorphic from "@reach/utils/polymorphic";
-
-/*
- * Singleton state is fine because you don't server render
- * an alert (SRs don't read them on first load anyway)
- */
-let keys: RegionKeys = {
-  polite: -1,
-  assertive: -1,
-};
-
-let elements: ElementTypes = {
-  polite: {},
-  assertive: {},
-};
-
-let liveRegions: RegionElements = {
-  polite: null,
-  assertive: null,
-};
-
-let renderTimer: number | null;
-
-////////////////////////////////////////////////////////////////////////////////
 
 /**
  * Alert
@@ -72,14 +45,26 @@ const Alert = React.forwardRef(function Alert(
   const ref = useComposedRefs(forwardedRef, ownRef);
   const child = React.useMemo(
     () => (
-      <Comp {...props} ref={ref} data-reach-alert>
+      <Comp
+        {...props}
+        ref={ref}
+        data-reach-alert
+        // The status role is a type of live region and a container whose
+        // content is advisory information for the user that is not
+        // important enough to justify an alert, and is often presented as
+        // a status bar. When the role is added to an element, the browser
+        // will send out an accessible status event to assistive
+        // technology products which can then notify the user about it.
+        // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_status_role
+        role={regionType === "assertive" ? "alert" : "status"}
+        aria-live={regionType}
+      >
         {children}
       </Comp>
     ),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [children, props]
   );
-  useMirrorEffects(regionType, child, ownRef);
 
   return child;
 }) as Polymorphic.ForwardRefComponent<"div", AlertProps>;
@@ -105,130 +90,6 @@ if (__DEV__) {
     type: PropTypes.oneOf(["assertive", "polite"]),
   };
 }
-
-////////////////////////////////////////////////////////////////////////////////
-
-function createMirror(type: "polite" | "assertive", doc: Document): Mirror {
-  let key = ++keys[type];
-
-  let mount = (element: JSX.Element) => {
-    if (liveRegions[type]) {
-      elements[type][key] = element;
-      renderAlerts();
-    } else {
-      let node = doc.createElement("div");
-      node.setAttribute(`data-reach-live-${type}`, "true");
-      liveRegions[type] = node;
-      doc.body.appendChild(liveRegions[type]!);
-      mount(element);
-    }
-  };
-
-  let update = (element: JSX.Element) => {
-    elements[type][key] = element;
-    renderAlerts();
-  };
-
-  let unmount = () => {
-    delete elements[type][key];
-    renderAlerts();
-  };
-
-  return { mount, update, unmount };
-}
-
-function renderAlerts() {
-  if (renderTimer != null) {
-    window.clearTimeout(renderTimer);
-  }
-  renderTimer = window.setTimeout(() => {
-    Object.keys(elements).forEach((elementType) => {
-      let regionType: RegionTypes = elementType as RegionTypes;
-      let container = liveRegions[regionType]!;
-      if (container) {
-        ReactDOM.render(
-          <VisuallyHidden as="div">
-            <div
-              // The status role is a type of live region and a container whose
-              // content is advisory information for the user that is not
-              // important enough to justify an alert, and is often presented as
-              // a status bar. When the role is added to an element, the browser
-              // will send out an accessible status event to assistive
-              // technology products which can then notify the user about it.
-              // https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Techniques/Using_the_status_role
-              role={regionType === "assertive" ? "alert" : "status"}
-              aria-live={regionType}
-            >
-              {Object.keys(elements[regionType]).map((key) =>
-                React.cloneElement(elements[regionType][key], {
-                  key,
-                  ref: null,
-                })
-              )}
-            </div>
-          </VisuallyHidden>,
-          liveRegions[regionType]
-        );
-      }
-    });
-  }, 500);
-}
-
-function useMirrorEffects(
-  regionType: RegionTypes,
-  element: JSX.Element,
-  ref: React.RefObject<Element>
-) {
-  const prevType = usePrevious<RegionTypes>(regionType);
-  const mirror = React.useRef<Mirror | null>(null);
-  const mounted = React.useRef(false);
-  React.useEffect(() => {
-    const ownerDocument = getOwnerDocument(ref.current)!;
-
-    if (!mounted.current) {
-      mounted.current = true;
-      mirror.current = createMirror(regionType, ownerDocument);
-      mirror.current.mount(element);
-    } else if (prevType !== regionType) {
-      mirror.current && mirror.current.unmount();
-      mirror.current = createMirror(regionType, ownerDocument);
-      mirror.current.mount(element);
-    } else {
-      mirror.current && mirror.current.update(element);
-    }
-  }, [element, regionType, prevType, ref]);
-
-  React.useEffect(() => {
-    return () => {
-      mirror.current && mirror.current.unmount();
-    };
-  }, []);
-}
-
-////////////////////////////////////////////////////////////////////////////////
-// Types
-
-type Mirror = {
-  mount: (element: JSX.Element) => void;
-  update: (element: JSX.Element) => void;
-  unmount: () => void;
-};
-
-type RegionTypes = "polite" | "assertive";
-
-type ElementTypes = {
-  [key in RegionTypes]: {
-    [key: string]: JSX.Element;
-  };
-};
-
-type RegionElements<T extends HTMLElement = HTMLDivElement> = {
-  [key in RegionTypes]: T | null;
-};
-
-type RegionKeys = {
-  [key in RegionTypes]: number;
-};
 
 ////////////////////////////////////////////////////////////////////////////////
 // Exports


### PR DESCRIPTION
This pull request fixes bug #394 in an existing package ([Alert](https://github.com/reach/reach-ui/tree/develop/packages/alert)):

- [Visually hidden or not, content that dynamically changes can be used as an `aria-live` region](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/ARIA_Live_Regions).
- I tested http://localhost:9001/iframe.html?id=alert--basic-ts-ts&viewMode=story with VoiceOver on macOS (I was able to repro the bug before my changes, and after my changes I didn't hear the duplicated announcement). Also tested on Firefox and on Chrome. `control`+`option`+`a` to read whole page