### PR TITLE
Skip Nav - CSS improvement

### DIFF
--- a/packages/skip-nav/styles.css
+++ b/packages/skip-nav/styles.css
@@ -3,14 +3,8 @@
 }
 
 [data-reach-skip-nav-link] {
-  border: 0;
-  clip: rect(0 0 0 0);
-  height: 1px;
-  width: 1px;
-  margin: -1px;
-  padding: 0;
-  overflow: hidden;
-  position: absolute;
+  position: fixed;
+  top: -100%;
 }
 
 [data-reach-skip-nav-link]:focus {
@@ -22,5 +16,4 @@
   z-index: 1;
   width: auto;
   height: auto;
-  clip: auto;
 }

--- a/packages/skip-nav/styles.css
+++ b/packages/skip-nav/styles.css
@@ -9,7 +9,6 @@
 
 [data-reach-skip-nav-link]:focus {
   padding: 1rem;
-  position: fixed;
   top: 10px;
   left: 10px;
   background: white;


### PR DESCRIPTION
- [X] Use a meaningful title for the pull request. Include the name of the package modified.
- [X] Test the change in your own code (Compile and run).
- [X] Add or edit tests to reflect the change (Run with `yarn test`).
- [X] Ensure formatting is consistent with the project's Prettier configuration.
- [X] Tested with VoiceOver

**This pull request:**

- Improves CSS in an existing package, removing deprecated properties.
- The existing CSS rules could be simplified
- The existing CSS uses the `clip` property that is now deprectaed: https://www.w3.org/TR/css-masking-1/#propdef-clip

Other considerations:
Also tried the following CSS (which is recommended in several websites):

```
  position: absolute;
  transform: translateY(-100%);
  left: 50%;
```

But the problem is that it relies that `SkipNavLink` will be at the top of your page.
If a user puts it somewhere else, the text in `SkipNavLink` can be visible.
Since the current implementation supports that users can use `SkipNavLink`  wherever they want, the above snippet is not viable.