### PR TITLE
[@reach/tooltip] Change types to also allow using SVG elements

### DIFF
--- a/packages/tooltip/src/index.tsx
+++ b/packages/tooltip/src/index.tsx
@@ -229,7 +229,7 @@ function clearContextId() {
  *
  * @param params
  */
-function useTooltip<ElementType extends HTMLElement>({
+function useTooltip<ElementType extends HTMLElement | SVGSVGElement>({
   id: idProp,
   onPointerEnter,
   onPointerMove,
@@ -661,7 +661,7 @@ function useDisabledTriggerOnSafari({
 }: {
   disabled: boolean | undefined;
   isVisible: boolean;
-  ref: React.RefObject<HTMLElement>;
+  ref: React.RefObject<HTMLElement | SVGSVGElement>;
 }) {
   React.useEffect(() => {
     if (
@@ -768,7 +768,7 @@ function isTooltipVisible(id: string, initial?: boolean) {
 ////////////////////////////////////////////////////////////////////////////////
 // TYPES
 
-interface TriggerParams<ElementType extends HTMLElement> {
+interface TriggerParams<ElementType extends HTMLElement | SVGSVGElement> {
   "aria-describedby"?: string | undefined;
   "data-state": string;
   "data-reach-tooltip-trigger": string;


### PR DESCRIPTION
Hi there! 👋 Thanks for Reach UI!

I just wanted to add this types change which is necessary to use the exported `TriggerParams` generic type with `SVGSVGElement`, eg. when using the tooltip with an `<svg>` element as a child.

Without this change, TypeScript displays errors such as:

```
Type 'SVGSVGElement' does not satisfy the constraint 'HTMLElement'.
  Type 'SVGSVGElement' is missing the following properties from type 'HTMLElement': accessKey, accessKeyLabel, autocapitalize, dir, and 20 more.ts(2344)
```

<img width="467" alt="Screen Shot 2022-06-12 at 13 33 06" src="https://user-images.githubusercontent.com/1935696/173231156-5cdba17b-08d7-48ee-8601-9bdd3af4008e.png">



Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
