### PR TITLE
Documentation - Remove link to join Spectrum Community

### DIFF
--- a/website/src/pages/index.mdx
+++ b/website/src/pages/index.mdx
@@ -4,7 +4,6 @@ Reach UI seeks to become the accessible foundation of your React-based design sy
 
 You can get involved by:
 
-- Joining the [Spectrum Community](https://spectrum.chat/reach)
 - Following on [GitHub](https://github.com/reach/reach-ui)
 
 Each component is tested with Safari + VoiceOver, Firefox + NVDA, and Edge + JAWS. As the project matures we’ll get it audited by WebAIM to ensure that if you pick Reach UI, your app has a solid, accessible foundation.


### PR DESCRIPTION
This pull request removes a link from the README.md file with a call to action that no longer applies since the Spectrum Community can no longer be joined.
