### PR TITLE
Updated portal and utils to accept React 18 in package.json

### DIFF
--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -22,8 +22,8 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || 17.x",
-    "react-dom": "^16.8.0 || 17.x"
+    "react": "^16.8.0 || 17.x || 18.x",
+    "react-dom": "^16.8.0 || 17.x || 18.x"
   },
   "main": "dist/reach-portal.cjs.js",
   "module": "dist/reach-portal.esm.js",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -18,8 +18,8 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || 17.x",
-    "react-dom": "^16.8.0 || 17.x"
+    "react": "^16.8.0 || 17.x || 18.x",
+    "react-dom": "^16.8.0 || 17.x || 18.x"
   },
   "main": "dist/reach-utils.cjs.js",
   "module": "dist/reach-utils.esm.js",


### PR DESCRIPTION
This pull request simply updates the React dependency version for portal and utils (I haven't tested other packages on React 18 so I'm not comfortable updating those yet). 
