### PR TITLE
bug:popover - targetRef should be observed even when the popover is hidden

### DIFF
--- a/packages/popover/src/index.tsx
+++ b/packages/popover/src/index.tsx
@@ -73,7 +73,7 @@ const PopoverImpl = React.forwardRef(function PopoverImpl(
 ) {
   const popoverRef = React.useRef<HTMLDivElement>(null);
   const popoverRect = useRect(popoverRef, { observe: !props.hidden });
-  const targetRect = useRect(targetRef, { observe: !props.hidden });
+  const targetRect = useRect(targetRef, { observe: true });
   const ref = useComposedRefs(popoverRef, forwardedRef);
 
   useSimulateTabNavigationForReactTree(targetRef as any, popoverRef);


### PR DESCRIPTION
This PR is mainly fixing this [issue](https://github.com/reach/reach-ui/issues/942). 

Since the popover top position based on the `top` of `targetRect`.  When the page is scrolled, the `top` of `targetRect` is chagned. 

```
function getTopPosition(
  targetRect: PRect,
  popoverRect: PRect,
  isDirectionUp: boolean
) {
  return {
    top: isDirectionUp
      ? `${targetRect.top - popoverRect.height + window.pageYOffset}px`
      : `${targetRect.top + targetRect.height + window.pageYOffset}px`,
  };
}
```

We shouldn't observe the `targetRef` only when popover is shown, otherwise, the top position of popover calculation is not correct. 

---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
