### PR TITLE
Add peer dependency for React 18 in `visually-hidden` package

### DIFF
--- a/packages/visually-hidden/package.json
+++ b/packages/visually-hidden/package.json
@@ -21,8 +21,8 @@
     "react-dom": "^17.0.2"
   },
   "peerDependencies": {
-    "react": "^16.8.0 || 17.x",
-    "react-dom": "^16.8.0 || 17.x"
+    "react": "^16.8.0 || 17.x || 18.x",
+    "react-dom": "^16.8.0 || 17.x || 18.x"
   },
   "main": "dist/reach-visually-hidden.cjs.js",
   "module": "dist/reach-visually-hidden.esm.js",


### PR DESCRIPTION
Hey team, right now if you install this package with a fresh React 18 project, you get a `ERESOLVE unable to resolve dependency tree` and I made this small change so that not everyone needs to do the whole `--legacy-peer-deps` thing.

I can update it to `>=16.8` instead of adding the `||` if you'd prefer, too, and add other packages as well, but I started small in case there might be a reason to not do this.

This pull request:
- Adds additional features/functionality to an existing package