### PR TITLE
Document use of pnpm/turbo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,16 +15,16 @@ Then, run these commands:
 ```
 git clone git@github.com:reach/reach-ui.git
 cd reach-ui
-yarn install
-yarn build
+pnpm install
+pnpm build
 ```
 
 ## Root Repo Scripts:
 
 ```sh
-yarn build        # builds all packages
-yarn start        # starts storybook server
-yarn test         # runs tests in all packages
+pnpm build        # builds all packages
+pnpm dev        # starts storybook server
+pnpm test         # runs tests in all packages
 ```
 
 ## Running / Writing Examples
@@ -32,7 +32,7 @@ yarn test         # runs tests in all packages
 First do the steps in "Getting started", then start the Storybook server:
 
 ```
-yarn start
+pnpm dev
 ```
 
 Next, put a file in `packages/<component-dir>/examples/<name>.example.js` and make it look like this:
@@ -65,20 +65,20 @@ Now you can edit the files in `packages/*` and storybook will automatically relo
 First do the steps in "Getting Started", then:
 
 ```
-yarn test
+pnpm test
 ```
 
 Or if you want to run the tests as you edit files:
 
 ```
-yarn test --watch
+pnpm test --watch
 ```
 
 Often you'll want to just test the component you're working on:
 
 ```
 cd packages/<component-path>
-yarn test --watch
+pnpm test --watch
 ```
 
 ## Development Plans
@@ -106,9 +106,9 @@ The components to be built come from the the [Aria Practices Design Patterns and
 | 🛠      | Toggletip      |
 | ✅     | Tooltip        |
 
-## Releases
+## Releases [DEPRECATED]
 
-This is our current release process. It's not perfect, but it has almost the right balance of manual + automation for me. We might be able to put some of this in a script...
+This is (was?) our current release process. It's not perfect, but it has almost the right balance of manual + automation for me. We might be able to put some of this in a script...
 
 ```sh
 # First, run the build locally and make sure there are no problems

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
 		"url": "git+https://github.com/reach/reach-ui.git"
 	},
 	"scripts": {
+		"preinstall": "npx -y only-allow pnpm",
 		"build": "turbo run build --filter=@reach/* && node scripts/postbuild.js",
 		"test:react-16": "USE_REACT_16=true vitest",
 		"test:react-18": "USE_REACT_18=true vitest",


### PR DESCRIPTION
As per https://github.com/reach/reach-ui/issues/952, `README.md` currently directs folks to install and build the project with `yarn`. The project moved to `pnpm` about four weeks ago, so contributors will trip up if they follow the installation instructions as is, or realize there's a `pnpm-lock.yaml` file and not trust the README at all.

I've swapped out `yarn` for `pnpm` where I can (and also replaced the `start` command with `dev` as well). However, the README also details a release process based on the old Lerna flow before moving to Turborepo. I'm not at all sure what the current release process is, so I'm leaving the PR as a draft until I get some feedback.