### PR TITLE
Fix `auto-id` build for backwards compatibility with React <18

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ node_modules
 .env
 coverage
 
+# storybook
+/playground/storybook-static
+
 # website
 /website-deploy-key
 /website-deploy-key.pub

--- a/packages/auto-id/src/auto-id.ts
+++ b/packages/auto-id/src/auto-id.ts
@@ -87,15 +87,6 @@ function useId(
 function useId(): string | undefined;
 
 function useId(providedId?: number | string | undefined | null) {
-	// TODO: Remove error flag when updating internal deps to React 18. None of
-	// our tricks will play well with concurrent rendering anyway.
-	// @ts-expect-error
-	if (typeof React.useId === "function") {
-		// @ts-expect-error
-		let id = React.useId(providedId);
-		return providedId != null ? providedId : id;
-	}
-
 	// If this instance isn't part of the initial render, we don't have to do the
 	// double render/patch-up dance. We can just generate the ID and return it.
 	let initialId = providedId ?? (serverHandoffComplete ? genId() : null);

--- a/playground/stories/window-size/basic.example.js
+++ b/playground/stories/window-size/basic.example.js
@@ -1,5 +1,5 @@
 import * as React from "react";
-import WindowSize from "@reach/window-size";
+import { WindowSize } from "@reach/window-size";
 
 let name = "Basic";
 

--- a/playground/stories/window-size/basic.example.tsx
+++ b/playground/stories/window-size/basic.example.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import WindowSize from "@reach/window-size";
+import { WindowSize } from "@reach/window-size";
 
 let name = "Basic (TS)";
 

--- a/website/src/pages/window-size.mdx
+++ b/website/src/pages/window-size.mdx
@@ -28,7 +28,7 @@ yarn add @reach/window-size
 ```
 
 ```js
-import WindowSize, { useWindowSize } from "@reach/window-size";
+import { WindowSize, useWindowSize } from "@reach/window-size";
 ```
 
 ## Component API


### PR DESCRIPTION
## Summary

Fixes #921

TL;DR: the bundle of `@reach/auto-id` contains an import of `useId` from `react`. For versions of React <18 this import does not exist, causing an error when this package is used.

<img width="632" alt="image" src="https://user-images.githubusercontent.com/1110551/187094589-8a8ab51d-d2fb-4a8c-8f84-bc2f54950827.png">


This can also be seen in the Storybook playground build output (although Storybook shows a warning)

<img width="684" alt="image" src="https://user-images.githubusercontent.com/1110551/187094541-f8d735eb-d655-46e3-9813-5d187b6920d3.png">

To fix that, I suggest to remove that code and change the implementation once React >=18 is supported.

I also fixed another import issue shown by Storybook

<img width="682" alt="image" src="https://user-images.githubusercontent.com/1110551/187094658-da26695f-dffe-4672-803e-452e7a10146c.png">


---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [x] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [x] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
