### PR TITLE
Add peer dependency for React 18 in accordion package

### DIFF
--- a/packages/accordion/package.json
+++ b/packages/accordion/package.json
@@ -30,8 +30,8 @@
 		"tsup": "^6.1.3"
 	},
 	"peerDependencies": {
-		"react": "^16.8.0 || 17.x",
-		"react-dom": "^16.8.0 || 17.x"
+		"react": "^16.8.0 || 17.x || 18.x",
+		"react-dom": "^16.8.0 || 17.x || 18.x"
 	},
 	"main": "./src/reach-accordion.tsx",
 	"types": "./src/reach-accordion.tsx",


### PR DESCRIPTION
This one is pretty much exactly like #953!

Right now if you install this package with a fresh React 18 project, you get a `ERESOLVE unable to resolve dependency tree` and I made this small change so that not everyone needs to do the whole `--legacy-peer-deps` thing.

I can update it to `>=16.8` instead of adding the `||` if you'd prefer, too, and add other packages as well, but I started small in case there might be a reason to not do this.

This pull request:
- Adds additional features/functionality to an existing package