### PR TITLE
Add peer dependency for React 18 in combobox package

### DIFF
--- a/packages/combobox/package.json
+++ b/packages/combobox/package.json
@@ -34,8 +34,8 @@
 		"tsup": "^6.1.3"
 	},
 	"peerDependencies": {
-		"react": "^16.8.0 || 17.x",
-		"react-dom": "^16.8.0 || 17.x"
+		"react": "^16.8.0 || 17.x || 18.x",
+		"react-dom": "^16.8.0 || 17.x || 18.x"
 	},
 	"main": "./src/reach-combobox.tsx",
 	"types": "./src/reach-combobox.tsx",


### PR DESCRIPTION
Hey guys, right now if you install this package with a fresh React 18 project, you get a `ERESOLVE unable to resolve dependency` tree and I made this small change so that not everyone needs to do the whole `--legacy-peer-deps` thing.
