### PR TITLE
Make `index` param in `onChange` of Accordion non optional

### DIFF
--- a/packages/accordion/src/reach-accordion.tsx
+++ b/packages/accordion/src/reach-accordion.tsx
@@ -199,7 +199,7 @@ interface AccordionProps {
 	 *
 	 * @see Docs https://reach.tech/accordion#accordion-onchange
 	 */
-	onChange?(index?: number): void;
+	onChange?(index: number): void;
 	/**
 	 * Whether or not an uncontrolled accordion is read-only or controllable by a
 	 * user interaction.


### PR DESCRIPTION
This pull request:

- [x] Makes `index` param in the `onChange` prop of `Accordion` non optional.

I couldn't think of a reason why `index` was optional when the onChange was called. According to the docs this should not be optional, so this commit makes sure it's not optional.