### PR TITLE
@reach/dialog: restore caret deps

### DIFF
--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -19,8 +19,8 @@
 		"@reach/polymorphic": "workspace:*",
 		"@reach/portal": "workspace:*",
 		"@reach/utils": "workspace:*",
-		"react-focus-lock": "2.5.2",
-		"react-remove-scroll": "2.4.3"
+		"react-focus-lock": "^2.5.2",
+		"react-remove-scroll": "^2.4.3"
 	},
 	"devDependencies": {
 		"@reach-internal/dev": "workspace:*",


### PR DESCRIPTION
Version 0.18.0 of @reach/dialog changed `react-focus-lock` and `react-remove-scroll` from caret to exact dependencies. This resulted in downgraded dependencies in our project, creating bugs on our end. This PR reverses that change.  

- [ ] Use a meaningful title for the pull request. Include the name of the package modified.
- [ ] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [ ] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [ ] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
