### PR TITLE
Add peer dependency for React 18

### DIFF
--- a/packages/auto-id/package.json
+++ b/packages/auto-id/package.json
@@ -27,8 +27,8 @@
 		"tsup": "^6.1.3"
 	},
 	"peerDependencies": {
-		"react": "^16.8.0 || 17.x",
-		"react-dom": "^16.8.0 || 17.x"
+		"react": "^16.8.0 || 17.x || 18.x",
+		"react-dom": "^16.8.0 || 17.x || 18.x"
 	},
 	"main": "./src/reach-auto-id.ts",
 	"types": "./src/reach-auto-id.ts",


### PR DESCRIPTION
Hi, right now if you install this package with a latest React project, then it results in  peer dependency warnings and This one looks safe to update for reach/auto-id. Thanks

This pull request:

Adds additional features/functionality to an existing package