### PR TITLE
@reach/portal: Support Remounting in <Activity>

### DIFF
--- a/.changeset/red-bats-lie.md
+++ b/.changeset/red-bats-lie.md
@@ -1,0 +1,5 @@
+---
+"@reach/portal": patch
+---
+
+Support remounting <Portal> component inside of React's <Activity> component

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@reach/portal",
-	"version": "0.18.1",
+	"version": "0.18.0",
 	"description": "Declarative portals for React",
 	"author": "React Training <hello@reacttraining.com>",
 	"license": "MIT",

--- a/packages/portal/package.json
+++ b/packages/portal/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@reach/portal",
-	"version": "0.18.0",
+	"version": "0.18.1",
 	"description": "Declarative portals for React",
 	"author": "React Training <hello@reacttraining.com>",
 	"license": "MIT",

--- a/packages/portal/src/reach-portal.tsx
+++ b/packages/portal/src/reach-portal.tsx
@@ -71,6 +71,7 @@ const PortalImpl: React.FC<PortalProps> = ({
 		return () => {
 			if (portalNode.current && body) {
 				body.removeChild(portalNode.current);
+				portalNode.current = null;
 			}
 		};
 	}, [type, forceUpdate, containerRef]);


### PR DESCRIPTION
This ensures that the `portalNode` ref is reset to `null` when removing the `portalNode` element from the DOM. Without this the `<Portal>` doesn't properly re-add a node to the DOM when it's remounted inside of [React's `<Activity>` component](https://react.dev/reference/react/Activity#my-hidden-components-have-effects-that-arent-running).

Next.js 16's Cache Components use `<Activity>` to restore UI when navigating back via history, so without this change navigating backwards in history can break portals.

---

Thank you for contributing to Reach UI! Please fill in this template before submitting your PR to help us process your request more quickly.

- [x] Use a meaningful title for the pull request. Include the name of the package modified.
- [x] Test the change in your own code (Compile and run).
- [ ] Add or edit tests to reflect the change (Run with `yarn test`).
- [ ] Add or edit Storybook examples to reflect the change (Run with `yarn start`).
- [x] Ensure formatting is consistent with the project's Prettier configuration.
- [ ] Add documentation to support any new features.

This pull request:

- [ ] Creates a new package
- [x] Fixes a bug in an existing package
- [ ] Adds additional features/functionality to an existing package
- [ ] Updates documentation or example code
- [ ] Other

If creating a new package:

- [ ] Make sure the new package directory contains each of the following, and that their structure/formatting mirrors other related examples in the project:
  - [ ] `examples` directory
  - [ ] `src` directory with an `index.tsx` entry file
  - [ ] At least one example file per feature introduced by the new package
  - [ ] Base styles in a `style.css` file (if needed by the new package)
